### PR TITLE
Add a type guard to Validator

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ export class AppStoreServerAPIClient {
                     if (!validator.validate(responseBody)) {
                         throw new Error("Unexpected response body format")
                     }
-                    return responseBody as T
+                    return responseBody
                 });
             } else {
                 return r.json().then(responseBody => {

--- a/jwt_verification.ts
+++ b/jwt_verification.ts
@@ -145,7 +145,7 @@ export class SignedDataVerifier {
         throw new VerificationException(VerificationStatus.INVALID_CERTIFICATE)
       }
       try {
-        const decodedJWT = jsonwebtoken.decode(jwt) as T
+        const decodedJWT = jsonwebtoken.decode(jwt)
         if (!validator.validate(decodedJWT)) {
           throw new VerificationException(VerificationStatus.FAILURE)
         }

--- a/models/AccountTenure.ts
+++ b/models/AccountTenure.ts
@@ -19,7 +19,7 @@ export enum AccountTenure {
 }
 
 export class AccountTenureValidator implements Validator<AccountTenure> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is AccountTenure {
         return Object.values(AccountTenure).includes(obj)
     }
 }

--- a/models/AppTransaction.ts
+++ b/models/AppTransaction.ts
@@ -90,7 +90,7 @@ export interface AppTransaction {
 
 export class AppTransactionValidator implements Validator<AppTransaction> {
     static readonly environmentValidator = new EnvironmentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is AppTransaction {
         if ((typeof obj['appAppleId'] !== 'undefined') && !(typeof obj['appAppleId'] === "number")) {
             return false
         }

--- a/models/AutoRenewStatus.ts
+++ b/models/AutoRenewStatus.ts
@@ -13,7 +13,7 @@ export enum AutoRenewStatus {
 }
 
 export class AutoRenewStatusValidator implements Validator<AutoRenewStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is AutoRenewStatus {
         return Object.values(AutoRenewStatus).includes(obj)
     }
 }

--- a/models/CheckTestNotificationResponse.ts
+++ b/models/CheckTestNotificationResponse.ts
@@ -27,7 +27,7 @@ export interface CheckTestNotificationResponse {
 
 export class CheckTestNotificationResponseValidator implements Validator<CheckTestNotificationResponse> {
     static readonly sendAttemptItemValidator = new SendAttemptItemValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is CheckTestNotificationResponse {
         if ((typeof obj['signedPayload'] !== 'undefined') && !(typeof obj['signedPayload'] === "string" || obj['signedPayload'] instanceof String)) {
             return false
         }

--- a/models/ConsumptionStatus.ts
+++ b/models/ConsumptionStatus.ts
@@ -15,7 +15,7 @@ export enum ConsumptionStatus {
 }
 
 export class ConsumptionStatusValidator implements Validator<ConsumptionStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is ConsumptionStatus {
         return Object.values(ConsumptionStatus).includes(obj)
     }
 }

--- a/models/Data.ts
+++ b/models/Data.ts
@@ -56,7 +56,7 @@ export interface Data {
 
 export class DataValidator implements Validator<Data> {
     static readonly environmentValidator = new EnvironmentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is Data {
         if ((typeof obj['environment'] !== 'undefined') && !(DataValidator.environmentValidator.validate(obj['environment']))) {
             return false
         }

--- a/models/DeliveryStatus.ts
+++ b/models/DeliveryStatus.ts
@@ -17,7 +17,7 @@ export enum DeliveryStatus {
 }
 
 export class DeliveryStatusValidator implements Validator<DeliveryStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is DeliveryStatus {
         return Object.values(DeliveryStatus).includes(obj)
     }
 }

--- a/models/Environment.ts
+++ b/models/Environment.ts
@@ -13,7 +13,7 @@ export enum Environment {
 }
 
 export class EnvironmentValidator implements Validator<Environment> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is Environment {
         return Object.values(Environment).includes(obj)
     }
 }

--- a/models/ExpirationIntent.ts
+++ b/models/ExpirationIntent.ts
@@ -16,7 +16,7 @@ export enum ExpirationIntent {
 }
 
 export class ExpirationIntentValidator implements Validator<ExpirationIntent> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is ExpirationIntent {
         return Object.values(ExpirationIntent).includes(obj)
     }
 }

--- a/models/ExtendReasonCode.ts
+++ b/models/ExtendReasonCode.ts
@@ -15,7 +15,7 @@ export enum ExtendReasonCode {
 }
 
 export class ExtendReasonCodeValidator implements Validator<ExtendReasonCode> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is ExtendReasonCode {
         return Object.values(ExtendReasonCode).includes(obj)
     }
 }

--- a/models/ExtendRenewalDateResponse.ts
+++ b/models/ExtendRenewalDateResponse.ts
@@ -40,7 +40,7 @@ export interface ExtendRenewalDateResponse {
 
 
 export class ExtendRenewalDateResponseValidator implements Validator<ExtendRenewalDateResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is ExtendRenewalDateResponse {
         if ((typeof obj['originalTransactionId'] !== 'undefined') && !(typeof obj['originalTransactionId'] === "string" || obj['originalTransactionId'] instanceof String)) {
             return false
         }

--- a/models/FirstSendAttemptResult.ts
+++ b/models/FirstSendAttemptResult.ts
@@ -22,7 +22,7 @@ export enum FirstSendAttemptResult {
 }
 
 export class FirstSendAttemptResultValidator implements Validator<FirstSendAttemptResult> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is FirstSendAttemptResult {
         return Object.values(FirstSendAttemptResult).includes(obj)
     }
 }

--- a/models/HistoryResponse.ts
+++ b/models/HistoryResponse.ts
@@ -55,7 +55,7 @@ export interface HistoryResponse {
 
 export class HistoryResponseValidator implements Validator<HistoryResponse> {
     static readonly environmentValidator = new EnvironmentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is HistoryResponse {
         if ((typeof obj['revision'] !== 'undefined') && !(typeof obj['revision'] === "string" || obj['revision'] instanceof String)) {
             return false
         }

--- a/models/InAppOwnershipType.ts
+++ b/models/InAppOwnershipType.ts
@@ -13,7 +13,7 @@ export enum InAppOwnershipType {
 }
 
 export class InAppOwnershipTypeValidator implements Validator<InAppOwnershipType> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is InAppOwnershipType {
         return Object.values(InAppOwnershipType).includes(obj)
     }
 }

--- a/models/JWSRenewalInfoDecodedPayload.ts
+++ b/models/JWSRenewalInfoDecodedPayload.ts
@@ -121,7 +121,7 @@ export class JWSRenewalInfoDecodedPayloadValidator implements Validator<JWSRenew
     static readonly priceIncreaseStatusValidator = new PriceIncreaseStatusValidator()
     static readonly autoRenewStatusValidator = new AutoRenewStatusValidator()
     static readonly expirationIntentValidator = new ExpirationIntentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is JWSRenewalInfoDecodedPayload {
         if ((typeof obj['expirationIntent'] !== 'undefined') && !(JWSRenewalInfoDecodedPayloadValidator.expirationIntentValidator.validate(obj['expirationIntent']))) {
             return false
         }

--- a/models/JWSTransactionDecodedPayload.ts
+++ b/models/JWSTransactionDecodedPayload.ts
@@ -186,7 +186,7 @@ export class JWSTransactionDecodedPayloadValidator implements Validator<JWSTrans
     static readonly inAppOwnershipTypeValidator = new InAppOwnershipTypeValidator()
     static readonly typeValidator = new TypeValidator()
     static readonly transactionReasonValidator = new TransactionReasonValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is JWSTransactionDecodedPayload {
         if ((typeof obj['originalTransactionId'] !== 'undefined') && !(typeof obj['originalTransactionId'] === "string" || obj['originalTransactionId'] instanceof String)) {
             return false
         }

--- a/models/LastTransactionsItem.ts
+++ b/models/LastTransactionsItem.ts
@@ -42,7 +42,7 @@ export interface LastTransactionsItem {
 
 export class LastTransactionsItemValidator implements Validator<LastTransactionsItem> {
     static readonly statusValidator = new StatusValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is LastTransactionsItem {
         if ((typeof obj['status'] !== 'undefined') && !(LastTransactionsItemValidator.statusValidator.validate(obj['status']))) {
             return false
         }

--- a/models/LifetimeDollarsPurchased.ts
+++ b/models/LifetimeDollarsPurchased.ts
@@ -19,7 +19,7 @@ export enum LifetimeDollarsPurchased {
 }
 
 export class LifetimeDollarsPurchasedValidator implements Validator<LifetimeDollarsPurchased> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is LifetimeDollarsPurchased {
         return Object.values(LifetimeDollarsPurchased).includes(obj)
     }
 }

--- a/models/LifetimeDollarsRefunded.ts
+++ b/models/LifetimeDollarsRefunded.ts
@@ -19,7 +19,7 @@ export enum LifetimeDollarsRefunded {
 }
 
 export class LifetimeDollarsRefundedValidator implements Validator<LifetimeDollarsRefunded> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is LifetimeDollarsRefunded {
         return Object.values(LifetimeDollarsRefunded).includes(obj)
     }
 }

--- a/models/MassExtendRenewalDateResponse.ts
+++ b/models/MassExtendRenewalDateResponse.ts
@@ -19,7 +19,7 @@ export interface MassExtendRenewalDateResponse {
 
 
 export class MassExtendRenewalDateResponseValidator implements Validator<MassExtendRenewalDateResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is MassExtendRenewalDateResponse {
         if ((typeof obj['requestIdentifier'] !== 'undefined') && !(typeof obj['requestIdentifier'] === "string" || obj['requestIdentifier'] instanceof String)) {
             return false
         }

--- a/models/MassExtendRenewalDateStatusResponse.ts
+++ b/models/MassExtendRenewalDateStatusResponse.ts
@@ -47,7 +47,7 @@ export interface MassExtendRenewalDateStatusResponse {
 
 
 export class MassExtendRenewalDateStatusResponseValidator implements Validator<MassExtendRenewalDateStatusResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is MassExtendRenewalDateStatusResponse {
         if ((typeof obj['requestIdentifier'] !== 'undefined') && !(typeof obj['requestIdentifier'] === "string" || obj['requestIdentifier'] instanceof String)) {
             return false
         }

--- a/models/NotificationHistoryResponse.ts
+++ b/models/NotificationHistoryResponse.ts
@@ -34,7 +34,7 @@ export interface NotificationHistoryResponse {
 
 export class NotificationHistoryResponseValidator implements Validator<NotificationHistoryResponse> {
     static readonly notificationHistoryResponseItemValidator = new NotificationHistoryResponseValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is NotificationHistoryResponse {
         if ((typeof obj['paginationToken'] !== 'undefined') && !(typeof obj['paginationToken'] === "string" || obj['paginationToken'] instanceof String)) {
             return false
         }

--- a/models/NotificationHistoryResponseItem.ts
+++ b/models/NotificationHistoryResponseItem.ts
@@ -27,7 +27,7 @@ export interface NotificationHistoryResponseItem {
 
 export class NotificationHistoryResponseItemValidator implements Validator<NotificationHistoryResponseItem> {
     static readonly sendAttemptItemValidator = new SendAttemptItemValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is NotificationHistoryResponseItem {
         if ((typeof obj['signedPayload'] !== 'undefined') && !(typeof obj['signedPayload'] === "string" || obj['signedPayload'] instanceof String)) {
             return false
         }

--- a/models/NotificationTypeV2.ts
+++ b/models/NotificationTypeV2.ts
@@ -28,7 +28,7 @@ export enum NotificationTypeV2 {
 }
 
 export class NotificationTypeV2Validator implements Validator<NotificationTypeV2> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is NotificationTypeV2 {
          return Object.values(NotificationTypeV2).includes(obj)
      }
  }

--- a/models/OfferType.ts
+++ b/models/OfferType.ts
@@ -14,7 +14,7 @@ export enum OfferType {
 }
 
 export class OfferTypeValidator implements Validator<OfferType> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is OfferType {
         return Object.values(OfferType).includes(obj)
     }
 }

--- a/models/OrderLookupResponse.ts
+++ b/models/OrderLookupResponse.ts
@@ -26,7 +26,7 @@ export interface OrderLookupResponse {
 
 export class OrderLookupResponseValidator implements Validator<OrderLookupResponse> {
     static readonly statusValidator = new OrderLookupStatusValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is OrderLookupResponse {
         if ((typeof obj['status'] !== 'undefined') && !(OrderLookupResponseValidator.statusValidator.validate(obj['status']))) {
             return false
         }

--- a/models/OrderLookupStatus.ts
+++ b/models/OrderLookupStatus.ts
@@ -13,7 +13,7 @@ export enum OrderLookupStatus {
 }
 
 export class OrderLookupStatusValidator implements Validator<OrderLookupStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is OrderLookupStatus {
         return Object.values(OrderLookupStatus).includes(obj)
     }
 }

--- a/models/Platform.ts
+++ b/models/Platform.ts
@@ -14,7 +14,7 @@ export enum Platform {
 }
 
 export class PlatformValidator implements Validator<Platform> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is Platform {
         return Object.values(Platform).includes(obj)
     }
 }

--- a/models/PlayTime.ts
+++ b/models/PlayTime.ts
@@ -19,7 +19,7 @@ export enum PlayTime {
 }
 
 export class PlayTimeValidator implements Validator<PlayTime> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is PlayTime {
         return Object.values(PlayTime).includes(obj)
     }
 }

--- a/models/PriceIncreaseStatus.ts
+++ b/models/PriceIncreaseStatus.ts
@@ -13,7 +13,7 @@ export enum PriceIncreaseStatus {
 }
 
 export class PriceIncreaseStatusValidator implements Validator<PriceIncreaseStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is PriceIncreaseStatus {
         return Object.values(PriceIncreaseStatus).includes(obj)
     }
 }

--- a/models/RefundHistoryResponse.ts
+++ b/models/RefundHistoryResponse.ts
@@ -32,7 +32,7 @@ export interface RefundHistoryResponse {
 
 
 export class RefundHistoryResponseValidator implements Validator<RefundHistoryResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is RefundHistoryResponse {
         if (typeof obj['signedTransactions'] !== 'undefined') {
             if (!Array.isArray(obj['signedTransactions'])) {
                 return false

--- a/models/ResponseBodyV2.ts
+++ b/models/ResponseBodyV2.ts
@@ -19,7 +19,7 @@ export interface ResponseBodyV2 {
 
 
 export class ResponseBodyV2Validator implements Validator<ResponseBodyV2> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is ResponseBodyV2 {
         if ((typeof obj['signedPayload'] !== 'undefined') && !(typeof obj['signedPayload'] === "string" || obj['signedPayload'] instanceof String)) {
             return false
         }

--- a/models/ResponseBodyV2DecodedPayload.ts
+++ b/models/ResponseBodyV2DecodedPayload.ts
@@ -72,7 +72,7 @@ export class ResponseBodyV2DecodedPayloadValidator implements Validator<Response
     static readonly subtypeValidator = new SubtypeValidator()
     static readonly dataValidator = new DataValidator()
     static readonly summaryValidator = new SummaryValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is ResponseBodyV2DecodedPayload {
         if ((typeof obj['notificationType'] !== 'undefined') && !(ResponseBodyV2DecodedPayloadValidator.notificationTypeValidator.validate(obj['notificationType']))) {
             return false
         }

--- a/models/RevocationReason.ts
+++ b/models/RevocationReason.ts
@@ -13,7 +13,7 @@ export enum RevocationReason {
 }
 
 export class RevocationReasonValidator implements Validator<RevocationReason> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is RevocationReason {
         return Object.values(RevocationReason).includes(obj)
     }
 }

--- a/models/SendAttemptItem.ts
+++ b/models/SendAttemptItem.ts
@@ -27,7 +27,7 @@ export interface SendAttemptItem {
 
 export class SendAttemptItemValidator implements Validator<SendAttemptItem> {
     static readonly sendAttemptResultValidator = new SendAttemptResultValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is SendAttemptItem {
         if ((typeof obj['attemptDate'] !== 'undefined') && !(typeof obj['attemptDate'] === "number")) {
             return false
         }

--- a/models/SendAttemptResult.ts
+++ b/models/SendAttemptResult.ts
@@ -22,7 +22,7 @@ export enum SendAttemptResult {
 }
 
 export class SendAttemptResultValidator implements Validator<SendAttemptResult> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is SendAttemptResult {
         return Object.values(SendAttemptResult).includes(obj)
     }
 }

--- a/models/SendTestNotificationResponse.ts
+++ b/models/SendTestNotificationResponse.ts
@@ -19,7 +19,7 @@ export interface SendTestNotificationResponse {
 
 
 export class SendTestNotificationResponseValidator implements Validator<SendTestNotificationResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is SendTestNotificationResponse {
         if ((typeof obj['testNotificationToken'] !== 'undefined') && !(typeof obj['testNotificationToken'] === "string" || obj['testNotificationToken'] instanceof String)) {
             return false
         }

--- a/models/Status.ts
+++ b/models/Status.ts
@@ -16,7 +16,7 @@ export enum Status {
 }
 
 export class StatusValidator implements Validator<Status> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is Status {
         return Object.values(Status).includes(obj)
     }
 }

--- a/models/StatusResponse.ts
+++ b/models/StatusResponse.ts
@@ -41,7 +41,7 @@ export interface StatusResponse {
 
 export class StatusResponseValidator implements Validator<StatusResponse> {
     static readonly environmentValidator = new EnvironmentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is StatusResponse {
         if ((typeof obj['environment'] !== 'undefined') && !(StatusResponseValidator.environmentValidator.validate(obj['environment']))) {
             return false
         }

--- a/models/SubscriptionGroupIdentifierItem.ts
+++ b/models/SubscriptionGroupIdentifierItem.ts
@@ -25,7 +25,7 @@ export interface SubscriptionGroupIdentifierItem {
 
 
 export class SubscriptionGroupIdentifierItemValidator implements Validator<SubscriptionGroupIdentifierItem> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is SubscriptionGroupIdentifierItem {
         if ((typeof obj['subscriptionGroupIdentifier'] !== 'undefined') && !(typeof obj['subscriptionGroupIdentifier'] === "string" || obj['subscriptionGroupIdentifier'] instanceof String)) {
             return false
         }

--- a/models/Subtype.ts
+++ b/models/Subtype.ts
@@ -27,7 +27,7 @@ export enum Subtype {
 }
 
 export class SubtypeValidator implements Validator<Subtype> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is Subtype {
         return Object.values(Subtype).includes(obj)
     }
 }

--- a/models/Summary.ts
+++ b/models/Summary.ts
@@ -69,7 +69,7 @@ export interface Summary {
 
 export class SummaryValidator implements Validator<Summary> {
     static readonly environmentValidator = new EnvironmentValidator()
-    validate(obj: any): boolean {
+    validate(obj: any): obj is Summary {
         if ((typeof obj['environment'] !== 'undefined') && !(SummaryValidator.environmentValidator.validate(obj['environment']))) {
             return false
         }

--- a/models/TransactionInfoResponse.ts
+++ b/models/TransactionInfoResponse.ts
@@ -19,7 +19,7 @@ export interface TransactionInfoResponse {
 
 
 export class TransactionInfoResponseValidator implements Validator<TransactionInfoResponse> {
-    validate(obj: any): boolean {
+    validate(obj: any): obj is TransactionInfoResponse {
         if ((typeof obj['signedTransactionInfo'] !== 'undefined') && !(typeof obj['signedTransactionInfo'] === "string" || obj['signedTransactionInfo'] instanceof String)) {
             return false
         }

--- a/models/TransactionReason.ts
+++ b/models/TransactionReason.ts
@@ -13,7 +13,7 @@ export enum TransactionReason {
 }
 
 export class TransactionReasonValidator implements Validator<TransactionReason> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is TransactionReason {
         return Object.values(TransactionReason).includes(obj)
     }
 }

--- a/models/Type.ts
+++ b/models/Type.ts
@@ -15,7 +15,7 @@ export enum Type {
 }
 
 export class TypeValidator implements Validator<Type> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is Type {
         return Object.values(Type).includes(obj)
     }
 }

--- a/models/UserStatus.ts
+++ b/models/UserStatus.ts
@@ -16,7 +16,7 @@ export enum UserStatus {
 }
 
 export class UserStatusValidator implements Validator<UserStatus> {
-   validate(obj: any): boolean {
+   validate(obj: any): obj is UserStatus {
         return Object.values(UserStatus).includes(obj)
     }
 }

--- a/models/Validator.ts
+++ b/models/Validator.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 export interface Validator<T> {
-    validate(obj: any): boolean
+    validate(obj: any): obj is T
 }


### PR DESCRIPTION
Happy WWDC! 🎉🥳

This PR adds a type guard to Validator's `validate` function to make it even more type safe.

TypeScript documentation: 
* https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates

By doing this, type casting like followings are automatically done and no longer necessary:
* https://github.com/apple/app-store-server-library-node/compare/main...chuganzy:type-guard?expand=1#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L131
* https://github.com/apple/app-store-server-library-node/compare/main...chuganzy:type-guard?expand=1#diff-218e5135f633cf5e28956d49ed301eb90f4a9c756537b5188407d02102b9bf69R148

## Checklist

- [x] `build` passes
- [x] `test` passes