### PR TITLE
Update PR Builder to use node 20 instead of 19

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [ 16.x, 18.x, 19.x ]
+        node: [ 16.x, 18.x, 20.x ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node 19 has reached end of life, giving room to the next LTS version (node 20).

Reference: https://endoflife.date/nodejs