### PR TITLE
Change the verification example to use the main type interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ try {
 ### Verification Usage
 
 ```typescript
-import { SignedDataVerifier } from "@apple/app-store-server-library/dist/jwt_verification"
+import { SignedJWTVerifier } from "@apple/app-store-server-library"
 
 const bundleId = "com.example"
 const appleRootCAs: Buffer[] = loadRootCAs() // Specific implementation may vary
 const enableOnlineChecks = true
 const environment = Environment.SANDBOX
-const verifier = new SignedDataVerifier(appleRootCAs, enableOnlineChecks, environment, bundleId)
+const verifier = new SignedJWTVerifier(appleRootCAs, enableOnlineChecks, environment, bundleId)
 
 const notificationPayload = "ey..."
 const verifiedNotification = await verifier.verifyAndDecodeNotification()


### PR DESCRIPTION
### Documentation Contribution

The interface at "@apple/app-store-server-library" exposes `SignedJWTVerifier` as the external type to be used.  
All other examples use this interface as reference for their imported types. 

But **_Verification Usage_** was importing directly the inner type `SignedDataVerifier`. 
To make it easier to new devs to onboard on the library, this PR conforms the example to the same interface and expected type.

Thanks for maintaining this project and making our lives easier working with IAP 🥳 