### PR TITLE
Fix: jsrsasign package audit issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -81,7 +81,7 @@ import { URLSearchParams } from 'url';
 export class AppStoreServerAPIClient {
     private static PRODUCTION_URL = "https://api.storekit.itunes.apple.com";
     private static SANDBOX_URL = "https://api.storekit-sandbox.itunes.apple.com";
-    private static USER_AGENT = "app-store-server-library/node/1.0.0";
+    private static USER_AGENT = "app-store-server-library/node/1.0.1";
 
     private issuerId: string
     private keyId: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apple/app-store-server-library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The App Store Server Library",
   "main": "dist/index.js",
   "keywords": [],
@@ -12,12 +12,12 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@types/jsonwebtoken": "^8.5.9",
-    "@types/jsrsasign": "^10.5.8",
+    "@types/jsrsasign": "^10.5.12",
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.3",
     "base64url": "^3.0.1",
     "jsonwebtoken": "^9.0.2",
-    "jsrsasign": "^10.9.0",
+    "jsrsasign": "^11.0.0",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,10 +753,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jsrsasign@^10.5.8":
-  version "10.5.8"
-  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-10.5.8.tgz#0d6c638505454b5e95c684d6f604d57641417336"
-  integrity sha512-1oZ3TbarAhKtKUpyrCIqXpbx3ZAfoSulleJs6/UzzyYty0ut+kjRX7zHLAaHwVIuw8CBjIymwW4J2LK944HoHQ==
+"@types/jsrsasign@^10.5.12":
+  version "10.5.12"
+  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-10.5.12.tgz#39ca12e576249f1a5494943d1c0c49c9087bf13d"
+  integrity sha512-sOA+eVnHU+FziThpMhuqs/tjFKe5gHVJKIS7g1BzhXP+e2FS8OvtzM0K3IzFxVksDOr98Gz5FJiZVxZ9uFoHhw==
 
 "@types/node-fetch@^2.6.3":
   version "2.6.4"
@@ -1937,10 +1937,10 @@ jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jsrsasign@^10.9.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.9.0.tgz#cc3f316e7e4c112a976193f9d2c93deb5a0745ee"
-  integrity sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==
+jsrsasign@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-11.0.0.tgz#766570c21f87d68075a142f5188f7e583cee9d70"
+  integrity sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==
 
 jwa@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION

Fix issue with:
```
# npm audit report

jsrsasign  <11.0.0
Severity: high
Marvin Attack of RSA and RSAOAEP decryption in jsrsasign - https://github.com/advisories/GHSA-rh63-9qcf-83gf
No fix available
node_modules/jsrsasign
  @apple/app-store-server-library  *
  Depends on vulnerable versions of jsrsasign
  node_modules/@apple/app-store-server-library
```