### PR TITLE
docs: add verification through gettransctioninfo api sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ try {
 }
 ```
 
+### Verification Through API Usage
+
+```typescript
+import { AppStoreServerAPIClient, Environment, SendTestNotificationResponse } from "@apple/app-store-server-library"
+
+const issuerId = "99b16628-15e4-4668-972b-eeff55eeff55"
+const keyId = "ABCDEFGHIJ"
+const bundleId = "com.example"
+const filePath = "/path/to/key/SubscriptionKey_ABCDEFGHIJ.p8"
+const encodedKey = readFile(filePath) // Specific implementation may vary
+const environment = Environment.PRODUCTION
+const transctionId = '123567891'
+
+const client = new AppStoreServerAPIClient(encodedKey, keyId, issuerId, bundleId, environment)
+
+try {
+    const response: TransactionInfoResponse = await client.getTransactionInfo(transctionId)
+    console.log(response)
+} catch (e) {
+    let error = e as APIException
+    if (error.apiError === APIError.TRANSACTION_ID_NOT_FOUND) {
+        const clientProd = new AppStoreServerAPIClient(encodedKey, keyId, issuerId, bundleId, Environment.SANDBOX)
+        try {
+            const responseProd: TransactionInfoResponse = await clientProd.getTransactionInfo(transctionId)
+            console.log(responseProd)
+        } catch (e) {
+            console.log(e)
+        }
+    }
+}
+```
+
 ### Verification Usage
 
 ```typescript


### PR DESCRIPTION
Add one sample codes per this doc https://developer.apple.com/documentation/appstoreserverapi#3820693

> If you don’t have environment information, follow these steps:

> - Call the endpoint using the production URL. If the call succeeds, the transaction identifier belongs to the production environment.

> - If you receive an error code 4040010 [TransactionIdNotFoundError](https://developer.apple.com/documentation/appstoreserverapi/transactionidnotfounderror), call the endpoint using the sandbox environment.

> - If the call succeeds, the transaction identifier belongs to the sandbox environment. If the call fails with the same error code, the transaction identifier isn’t present in either environment.