### PR TITLE
Use placeholder URL when LOCAL_TESTING environment option is provided

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -81,6 +81,7 @@ import { URLSearchParams } from 'url';
 export class AppStoreServerAPIClient {
     private static PRODUCTION_URL = "https://api.storekit.itunes.apple.com";
     private static SANDBOX_URL = "https://api.storekit-sandbox.itunes.apple.com";
+    private static LOCAL_TESTING_URL = "https://local-testing-base-url";
     private static USER_AGENT = "app-store-server-library/node/1.1.0";
 
     private issuerId: string
@@ -102,7 +103,19 @@ export class AppStoreServerAPIClient {
         this.keyId = keyId
         this.bundleId = bundleId
         this.signingKey = signingKey
-        this.urlBase = environment === "Sandbox" ? AppStoreServerAPIClient.SANDBOX_URL : AppStoreServerAPIClient.PRODUCTION_URL
+        switch(environment) {
+            case Environment.XCODE:
+                throw new Error("Xcode is not a supported environment for an AppStoreServerAPIClient")
+            case Environment.PRODUCTION:
+                this.urlBase = AppStoreServerAPIClient.PRODUCTION_URL
+                break
+            case Environment.LOCAL_TESTING:
+                this.urlBase = AppStoreServerAPIClient.LOCAL_TESTING_URL
+                break
+            case Environment.SANDBOX:
+                this.urlBase = AppStoreServerAPIClient.SANDBOX_URL
+                break
+        }
     }
 
     protected async makeRequest<T>(path: string, method: string, queryParameters: { [key: string]: string[]}, body: object | null, validator: Validator<T> | null): Promise<T> {

--- a/models/Environment.ts
+++ b/models/Environment.ts
@@ -11,7 +11,7 @@ export enum Environment {
     SANDBOX = "Sandbox",
     PRODUCTION = "Production",
     XCODE = "Xcode",
-    LOCAL_TESTING = "LocalTesting",
+    LOCAL_TESTING = "LocalTesting", // Used for unit testing
 }
 
 export class EnvironmentValidator extends StringValidator {}

--- a/tests/unit-tests/api_client.test.ts
+++ b/tests/unit-tests/api_client.test.ts
@@ -57,8 +57,12 @@ function getClientWithBody(path: string, callback: callbackType, statusCode: num
 }
 
 function getAppStoreServerAPIClient(body: string, statusCode: number, callback: callbackType): AppStoreServerAPIClient {
-    const key = readFile('tests/resources/certs/testSigningKey.p8')
+    const key = getSigningKey()
     return new AppStoreServerAPIClientForTest(key, "keyId", "issuerId", "bundleId", Environment.LOCAL_TESTING, callback, body, statusCode)
+}
+
+function getSigningKey(): string {
+    return readFile('tests/resources/certs/testSigningKey.p8')
 }
 
 describe('The api client ', () => {
@@ -499,5 +503,16 @@ describe('The api client ', () => {
         } catch (e) {
             return;
         }
+     })
+     
+     it('throws an error when the XCODE environment is passed', async () => {
+         try {
+            const key = getSigningKey()
+            new AppStoreServerAPIClient(key, "keyId", "issuerId", "bundleId", Environment.XCODE)
+            fail('this test call is expected to throw')
+         } catch (e) {
+            let error = e as Error
+            expect(error.message).toBe("Xcode is not a supported environment for an AppStoreServerAPIClient")
+         }
      })
 })


### PR DESCRIPTION
Block creation of an AppStoreServerAPIClient with environment XCODE