### PR TITLE
avoid error if transactionHistoryRequest is not passed (especially while using js)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -292,34 +292,36 @@ export class AppStoreServerAPIClient {
      * @throws APIException If a response was returned indicating the request could not be processed
      * {@link https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history Get Transaction History}
      */
-    public async getTransactionHistory(transactionId: string, revision: string | null, transactionHistoryRequest: TransactionHistoryRequest): Promise<HistoryResponse> {
+    public async getTransactionHistory(transactionId: string, revision: string | null, transactionHistoryRequest?: TransactionHistoryRequest): Promise<HistoryResponse> {
         const queryParameters: { [key: string]: string[]} = {}
         if (revision != null) {
             queryParameters["revision"] = [revision];
         }
-        if (transactionHistoryRequest.startDate) {
-            queryParameters["startDate"] = [transactionHistoryRequest.startDate.toString()];
-        }
-        if (transactionHistoryRequest.endDate) {
-            queryParameters["endDate"] = [transactionHistoryRequest.endDate.toString()];
-        }
-        if (transactionHistoryRequest.productIds) {
-            queryParameters["productId"] = transactionHistoryRequest.productIds;
-        }
-        if (transactionHistoryRequest.productTypes) {
-            queryParameters["productType"] = transactionHistoryRequest.productTypes;
-        }
-        if (transactionHistoryRequest.sort) {
-            queryParameters["sort"] = [transactionHistoryRequest.sort];
-        }
-        if (transactionHistoryRequest.subscriptionGroupIdentifiers) {
-            queryParameters["subscriptionGroupIdentifier"] = transactionHistoryRequest.subscriptionGroupIdentifiers;
-        }
-        if (transactionHistoryRequest.inAppOwnershipType) {
-            queryParameters["inAppOwnershipType"] = [transactionHistoryRequest.inAppOwnershipType];
-        }
-        if (transactionHistoryRequest.revoked !== undefined) {
-            queryParameters["revoked"] = [transactionHistoryRequest.revoked.toString()];
+        if (transactionHistoryRequest) {
+            if (transactionHistoryRequest.startDate) {
+                queryParameters["startDate"] = [transactionHistoryRequest.startDate.toString()];
+            }
+            if (transactionHistoryRequest.endDate) {
+                queryParameters["endDate"] = [transactionHistoryRequest.endDate.toString()];
+            }
+            if (transactionHistoryRequest.productIds) {
+                queryParameters["productId"] = transactionHistoryRequest.productIds;
+            }
+            if (transactionHistoryRequest.productTypes) {
+                queryParameters["productType"] = transactionHistoryRequest.productTypes;
+            }
+            if (transactionHistoryRequest.sort) {
+                queryParameters["sort"] = [transactionHistoryRequest.sort];
+            }
+            if (transactionHistoryRequest.subscriptionGroupIdentifiers) {
+                queryParameters["subscriptionGroupIdentifier"] = transactionHistoryRequest.subscriptionGroupIdentifiers;
+            }
+            if (transactionHistoryRequest.inAppOwnershipType) {
+                queryParameters["inAppOwnershipType"] = [transactionHistoryRequest.inAppOwnershipType];
+            }
+            if (transactionHistoryRequest.revoked !== undefined) {
+                queryParameters["revoked"] = [transactionHistoryRequest.revoked.toString()];
+            }
         }
         return await this.makeRequest("/inApps/v1/history/" + transactionId, "GET", queryParameters, null, new HistoryResponseValidator());
     }


### PR DESCRIPTION
While calling `client.getTransactionHistory(transactionId)`, I was getting an error:

```
/home/bhavya/Documents/app-store-server-library-node/node_modules/@apple/app-store-server-library/dist/index.js:263
        if (transactionHistoryRequest.startDate) {
                                      ^

TypeError: Cannot read properties of undefined (reading 'startDate')
    at AppStoreServerAPIClient.getTransactionHistory (/home/bhavya/Documents/app-store-server-library-node/node_modules/@apple/app-store-server-library/dist/index.js:263:39)
    at /home/bhavya/Documents/app-store-server-library-node/test.js:16:45
    at Object.<anonymous> (/home/bhavya/Documents/app-store-server-library-node/test.js:18:3)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.10.0
```
I saw that I had to pass empty object `client.getTransactionHistory(transactionId, null , {})` along with null value in previous argument, but I didn't have any parameters in my case, so I fixed it by checking the third argument if it does exist, and because I used `javascript` instead of `typescript` in my case, so `typescript` related error like the argument is required didn't came.

@federicobucchi @hkrdotptr @madrob @kolecke 