### PR TITLE
Update README with description for legacy app receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ const verifiedNotification = await verifier.verifyAndDecodeNotification(notifica
 console.log(verifiedNotification)
 ```
 
-### Receipt Usage
+### Receipt Usage (For Legacy App Receipts)
+If you use an App Receipt from [Original StoreKit](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/validating_receipts_with_the_app_store), you can utilize `ReceiptUtility` to verify the legacy receipt.
 
 ```typescript
 import { AppStoreServerAPIClient, Environment, GetTransactionHistoryVersion, ReceiptUtility, Order, ProductType, HistoryResponse, TransactionHistoryRequest } from "@apple/app-store-server-library"


### PR DESCRIPTION
I understood that `ReceiptUtility` is for legacy app receipt from this issue and comment.
https://github.com/apple/app-store-server-library-node/issues/84#issuecomment-1951663446

So I think it is recommend to be written at README.
That's why I modified README.

Please review it!