### PR TITLE
Update node version in CI

### DIFF
--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [ 18.x, 20.x, 22.x ]
+        node: [ 20.x, 22.x, 24.x ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-prb.yml
+++ b/.github/workflows/ci-prb.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [ 20.x, 22.x, 24.x ]
+        node: [ 18.x, 20.x, 22.x, 24.x ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-release-docs.yml
+++ b/.github/workflows/ci-release-docs.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node 18.x
+      - name: Use Node 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
       - name: Build


### PR DESCRIPTION
Node 18 is no longer maintained and node 24 is now available.

Ref: https://endoflife.date/nodejs

This PR adds node 24 to the PR Builder to allow us to test in v24 as well. I kept node 18 for now, since that's the version currently in use by the Publish Library CI. If we decide that we can bump the version in Publish Library to node 20 and that it'll not break compatibility with node 18, we can remove node 18 from the PR Builder as well at some point (it's probably a good idea to keep node 18 in the PR Builder until it is announced that v18 is no longer supported).

Additionally, this PR updates the node version from 18 to 20 in the Doc Builder CI.
