### PR TITLE
Add support for signingKey as KeyObject

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import fetch from 'node-fetch';
+import type { KeyObject } from 'crypto';
 import { CheckTestNotificationResponse, CheckTestNotificationResponseValidator } from './models/CheckTestNotificationResponse';
 import { ConsumptionRequest } from './models/ConsumptionRequest';
 import { UpdateAppAccountTokenRequest } from './models/UpdateAppAccountTokenRequest'
@@ -114,7 +115,7 @@ export class AppStoreServerAPIClient {
 
     private issuerId: string
     private keyId: string
-    private signingKey: string
+    private signingKey: string | KeyObject
     private bundleId: string
     private urlBase: string
 
@@ -126,7 +127,7 @@ export class AppStoreServerAPIClient {
      * @param bundleId Your app’s bundle ID
      * @param environment The environment to target
      */
-    public constructor(signingKey: string, keyId: string, issuerId: string, bundleId: string, environment: Environment) {
+    public constructor(signingKey: string | KeyObject, keyId: string, issuerId: string, bundleId: string, environment: Environment) {
         this.issuerId = issuerId
         this.keyId = keyId
         this.bundleId = bundleId

--- a/tests/unit-tests/api_client.test.ts
+++ b/tests/unit-tests/api_client.test.ts
@@ -19,6 +19,7 @@ import { InAppOwnershipType } from "../../models/InAppOwnershipType";
 import { RefundPreference } from "../../models/RefundPreference";
 import { APIError, APIException, AppStoreServerAPIClient, ExtendReasonCode, ExtendRenewalDateRequest, GetTransactionHistoryVersion, MassExtendRenewalDateRequest, NotificationHistoryRequest, NotificationHistoryResponseItem, Order, OrderLookupStatus, ProductType, SendAttemptResult, TransactionHistoryRequest } from "../../index";
 import { Response } from "node-fetch";
+import type { KeyObject } from "crypto";
 
 import jsonwebtoken = require('jsonwebtoken');
 
@@ -30,7 +31,7 @@ class AppStoreServerAPIClientForTest extends AppStoreServerAPIClient {
     private body: string
     private statusCode: number
 
-    public constructor(signingKey: string, keyId: string, issuerId: string, bundleId: string, environment: Environment, callback: callbackType, body: string, statusCode: number) {
+    public constructor(signingKey: string | KeyObject, keyId: string, issuerId: string, bundleId: string, environment: Environment, callback: callbackType, body: string, statusCode: number) {
         super(signingKey, keyId, issuerId, bundleId, environment)
         this.callback = callback
         this.body = body


### PR DESCRIPTION
While using this library we found that it was useful to also support signingKey as KeyObject, which is part of the types accepted by the jsonwebtoken.sign function.