### PR TITLE
Bump jsrsasign minimum version to 11.1.1 to address critical CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@types/jsonwebtoken": "^9.0.5",
-    "@types/jsrsasign": "^10.5.12",
+    "@types/jsrsasign": "^10.5.15",
     "@types/node": "^25.4.0",
     "@types/node-fetch": "^2.6.13",
     "base64url": "^3.0.1",
     "jsonwebtoken": "^9.0.2",
-    "jsrsasign": "^11.0.0",
+    "jsrsasign": "^11.1.1",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,7 +1050,7 @@
     "@types/ms" "*"
     "@types/node" "*"
 
-"@types/jsrsasign@^10.5.12":
+"@types/jsrsasign@^10.5.15":
   version "10.5.15"
   resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-10.5.15.tgz#5cf1ee506b2fa2435b6e1786a873285c7110eb82"
   integrity sha512-3stUTaSRtN09PPzVWR6aySD9gNnuymz+WviNHoTb85dKu+BjaV4uBbWWGykBBJkfwPtcNZVfTn2lbX00U+yhpQ==
@@ -2510,7 +2510,7 @@ jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jsrsasign@^11.0.0:
+jsrsasign@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-11.1.1.tgz#a6a213e52b835fd6292fae9903a165921578fc13"
   integrity sha512-6w95OOXH8DNeGxakqLndBEqqwQ6A70zGaky1oxfg8WVLWOnghTfJsc5Tknx+Z88MHSb1bGLcqQHImOF8Lk22XA==


### PR DESCRIPTION
## Summary

`npm audit` was showing critical vulnerability pointing to the `jsrsasign` dependency used by this project.

- Bumps the `jsrsasign` dependency floor from `^11.0.0` to `^11.1.1` to exclude versions affected by multiple critical vulnerabilities
- Versions prior to 11.1.1 are affected by CVE-2026-4599 (CVSS 9.1), CVE-2026-4600, and CVE-2026-4601 (CVSS 8.7), which enable private key recovery and signature forgery via flaws in the DSA signing implementation
- The lockfile already resolves to 11.1.1, so this change has no functional impact on this repository — it prevents downstream consumers from resolving a vulnerable version

Verified unit tests still passed.

Up to you all if you want to accept this PR or not but figured it was worth flagging at least.