### PR TITLE
Fix Xcode receipt parsing with strict ASN.1 lengths

### DIFF
--- a/receipt_utility.ts
+++ b/receipt_utility.ts
@@ -24,7 +24,7 @@ export class ReceiptUtility {
             const oldResult = prevGetVblenFunction(s, idx)
             // Round up to the remaining length in the string, measured in bytes (2 hex values per byte)
             if (oldResult === 0 && c === '80') {
-                return (s.length - idx) / 2
+                return (s.length - ASN1HEX.getVidx(s, idx)) / 2
             }
             return oldResult
         }


### PR DESCRIPTION
## Summary
- compute the synthetic value length for Xcode indefinite-length receipts from the value offset instead of the tag offset
- keeps `extractTransactionIdFromAppReceipt` compatible with the stricter ASN.1 length checks in `jsrsasign >= 11.1.2`

Closes #417.

## Testing
- reproduced the two failing Xcode receipt tests with `jsrsasign@11.1.3` before the fix
- `npx jest tests/unit-tests/receipt_utility.test.ts --runInBand`
- `npm run build`
- `git diff --check`