### PR TITLE
Add request timeout to App Store Server API client

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -195,6 +195,7 @@ export class AppStoreServerAPIClient {
     private static SANDBOX_URL = "https://api.storekit-sandbox.apple.com";
     private static LOCAL_TESTING_URL = "https://local-testing-base-url";
     private static USER_AGENT = "app-store-server-library/node/3.1.0";
+    private static REQUEST_TIMEOUT_MS = 30000;
 
     private issuerId: string
     private keyId: string
@@ -293,7 +294,8 @@ export class AppStoreServerAPIClient {
         return await fetch(this.urlBase + path + '?' + parsedQueryParameters, {
             method: method,
             body: requestBody,
-            headers: headers
+            headers: headers,
+            timeout: AppStoreServerAPIClient.REQUEST_TIMEOUT_MS
         });
     }
 


### PR DESCRIPTION
## Problem

`makeFetchRequest` (index.ts:292) issues requests with no timeout, and node-fetch applies no default. If a connection is accepted but never answered, the call hangs indefinitely rather than failing, so callers have no way to recover short of their own external timeout.

## Change

Adds a 30 second timeout to API requests.

The value matches what the library already does elsewhere:

- `jws_verification.ts:320` sets `timeout: 30000` on the OCSP request
- the Python library's `_execute_request` passes `timeout=30` on every request

so this looks like an oversight in the API client rather than a deliberate difference.

## Notes

**This is a behaviour change.** A request that currently takes longer than 30 seconds and eventually succeeds would now fail. I judged that acceptable given the Python library already enforces the same limit, but flagging it explicitly since it is not a pure bug fix.

**No test.** The existing `api_client.test.ts` subclass overrides `makeFetchRequest`, so the default implementation is not covered by the suite. Testing a timeout would need a deliberately unresponsive server, which tends to be flaky in CI. I left it untested rather than add a fragile test, but happy to add one if you would prefer.

**Not configurable.** A constructor option would be more flexible, but I kept the change minimal. Happy to follow up with one if that is wanted.

`yarn build` and `yarn test` pass (330 tests).

Related to #424.
