### PR TITLE
Add AppReceiptVerifier for signature validation of legacy app receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ if (transactionId != null) {
 }
 ```
 
+### App Receipt Verification Usage
+
+```typescript
+import { AppReceipt, AppReceiptVerifier, Environment } from "@apple/app-store-server-library"
+
+const bundleId = "com.example"
+const appleRootCAs: Buffer[] = loadRootCAs() // Specific implementation may vary
+const enableOnlineChecks = true
+const environment = Environment.SANDBOX
+const verifier = new AppReceiptVerifier(appleRootCAs, enableOnlineChecks, environment, bundleId)
+
+const appReceipt = "MI..."
+const receipt: AppReceipt = await verifier.verifyAndDecodeAppReceipt(appReceipt)
+console.log(receipt)
+
+const transactionId = await verifier.verifyAndExtractTransactionId(appReceipt)
+console.log(transactionId)
+```
+
 ### Promotional Offer Signature Creation
 
 ```typescript

--- a/app_receipt_verification.ts
+++ b/app_receipt_verification.ts
@@ -1,0 +1,706 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import { KeyObject, X509Certificate, createHash, timingSafeEqual, verify } from 'crypto';
+import { AppReceipt } from './models/AppReceipt';
+import { Environment } from './models/Environment';
+import { InAppPurchaseReceipt } from './models/InAppPurchaseReceipt';
+import { SignedDataVerifier, VerificationException, VerificationStatus } from './jws_verification';
+
+const RECEIPT_TYPE_TYPE_ID = 0;
+const BUNDLE_ID_TYPE_ID = 2;
+const APPLICATION_VERSION_TYPE_ID = 3;
+const OPAQUE_VALUE_TYPE_ID = 4;
+const SHA1_HASH_TYPE_ID = 5;
+const RECEIPT_CREATION_DATE_TYPE_ID = 12;
+const IN_APP_TYPE_ID = 17;
+const ORIGINAL_PURCHASE_DATE_TYPE_ID = 18;
+const ORIGINAL_APPLICATION_VERSION_TYPE_ID = 19;
+const EXPIRATION_DATE_TYPE_ID = 21;
+
+const QUANTITY_TYPE_ID = 1701;
+const PRODUCT_IDENTIFIER_TYPE_ID = 1702;
+const TRANSACTION_IDENTIFIER_TYPE_ID = 1703;
+const PURCHASE_DATE_TYPE_ID = 1704;
+const ORIGINAL_TRANSACTION_IDENTIFIER_TYPE_ID = 1705;
+const IN_APP_ORIGINAL_PURCHASE_DATE_TYPE_ID = 1706;
+const EXPIRES_DATE_TYPE_ID = 1708;
+const WEB_ORDER_LINE_ITEM_IDENTIFIER_TYPE_ID = 1711;
+const CANCELLATION_DATE_TYPE_ID = 1712;
+const IS_IN_INTRO_OFFER_PERIOD_TYPE_ID = 1719;
+
+const SIGNED_DATA_OID = '1.2.840.113549.1.7.2';
+const MESSAGE_DIGEST_OID = '1.2.840.113549.1.9.4';
+const SHA1_OID = '1.3.14.3.2.26';
+const SHA256_OID = '2.16.840.1.101.3.4.2.1';
+
+// Only the digests Apple signs receipts with; anything else is rejected
+const DIGEST_ALGORITHMS: { [index: string]: string } = {
+    [SHA1_OID]: 'sha1',
+    [SHA256_OID]: 'sha256'
+}
+
+// Leaf, intermediate and root, the same chain length the JWS x5c header claim carries
+const EXPECTED_CHAIN_LENGTH = 3;
+
+const BASE64_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+// RFC 3339, the format receipt date attributes carry
+const RFC_3339_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/
+
+/**
+ * Exposes the certificate chain verification of {@link SignedDataVerifier} to the app receipt verifier: the
+ * same caller-supplied Apple roots, the same Apple marker OID checks, the same OCSP path and public key cache.
+ * An app receipt is not JWS and carries no appAppleId, so the environment and bundle identifier of this
+ * instance are never consulted - only its root certificates and its online check flag are.
+ */
+class AppReceiptChainVerifier extends SignedDataVerifier {
+    constructor(appleRootCertificates: Buffer[], enableOnlineChecks: boolean) {
+        super(appleRootCertificates, enableOnlineChecks, Environment.SANDBOX, "")
+    }
+
+    async verifyReceiptCertificateChain(leaf: X509Certificate, intermediate: X509Certificate, effectiveDate: Date): Promise<KeyObject> {
+        return await this.verifyCertificateChain(this.rootCertificates, leaf, intermediate, effectiveDate)
+    }
+}
+
+/**
+ * A class providing utility methods for verifying and decoding legacy PKCS#7 App Store receipts, the app
+ * receipt used with the deprecated verifyReceipt endpoint.
+ *
+ * This is the validating counterpart to {@link ReceiptUtility}, which extracts without validation. The
+ * receipt's certificate chain is validated with the same code path used for JWS signed data, against the same
+ * caller-supplied Apple root certificates, and evaluated at the receipt's creation date so old receipts
+ * survive certificate rotations unless online checks are enabled.
+ *
+ * Example Usage:
+ * ```ts
+ * const verifier = new AppReceiptVerifier([appleRoot, appleRoot2], true, Environment.SANDBOX, "com.example")
+ *
+ * try {
+ *     const receipt = await verifier.verifyAndDecodeAppReceipt("MI...")
+ *     console.log(receipt)
+ * } catch (e) {
+ *     console.error(e)
+ * }
+ * ```
+ */
+export class AppReceiptVerifier {
+
+    protected chainVerifier: AppReceiptChainVerifier
+    protected enableOnlineChecks: boolean
+    protected environment: Environment
+    protected bundleId: string
+
+    /**
+     *
+     * @param appleRootCertificates A list of DER-encoded root certificates
+     * @param enableOnlineChecks Whether to enable revocation checking and check expiration using the current date
+     * @param environment The App Store environment to target for checks
+     * @param bundleId The app's bundle identifier
+     */
+    constructor(appleRootCertificates: Buffer[], enableOnlineChecks: boolean, environment: Environment, bundleId: string) {
+        this.chainVerifier = new AppReceiptChainVerifier(appleRootCertificates, enableOnlineChecks)
+        this.enableOnlineChecks = enableOnlineChecks
+        this.environment = environment
+        this.bundleId = bundleId
+    }
+
+    /**
+     * Verifies and decodes an app receipt, as obtained from a device
+     * See {@link https://developer.apple.com/documentation/appstorereceipts App Store Receipts}
+     *
+     * @param encodedReceipt The base64-encoded app receipt
+     * @return The decoded receipt after verification
+     * @throws VerificationException Thrown if the receipt could not be verified
+     */
+    async verifyAndDecodeAppReceipt(encodedReceipt: string): Promise<AppReceipt> {
+        try {
+            const signedData = parseSignedData(decodeBase64Receipt(encodedReceipt))
+            // Parsed before signature verification only to learn the creation date, which the chain validity is
+            // anchored at; nothing from it is trusted until the chain and signature checks pass
+            const receipt = parseReceiptPayload(signedData.content)
+            if (this.environment !== Environment.XCODE && this.environment !== Environment.LOCAL_TESTING) {
+                const effectiveDate = this.enableOnlineChecks || receipt.receiptCreationDate === undefined ? new Date() : new Date(receipt.receiptCreationDate)
+                const signerPublicKey = await this.verifyChain(signedData, effectiveDate)
+                verifySignature(signedData, signerPublicKey)
+            }
+            // In the Xcode and LocalTesting environments the data is not signed by the App Store and signature
+            // verification is skipped, but the bundle id and environment are still validated
+            this.validateBundleId(receipt.bundleId)
+            this.validateEnvironment(environmentForReceiptType(receipt.receiptType))
+            return receipt
+        } catch (error) {
+            if (error instanceof VerificationException) {
+                throw error
+            } else if (error instanceof Error) {
+                throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, error)
+            }
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE)
+        }
+    }
+
+    /**
+     * Verifies an app receipt and extracts a transaction id from its in-app purchases, the validated
+     * counterpart of {@link ReceiptUtility.extractTransactionIdFromAppReceipt} with the same output contract:
+     * a transaction id from the array of in-app purchases, or null if the receipt contains none.
+     *
+     * @param encodedReceipt The base64-encoded app receipt
+     * @return A transaction id from the receipt's in-app purchases, null if the receipt contains no in-app purchases
+     * @throws VerificationException Thrown if the receipt could not be verified
+     */
+    async verifyAndExtractTransactionId(encodedReceipt: string): Promise<string | null> {
+        const receipt = await this.verifyAndDecodeAppReceipt(encodedReceipt)
+        for (const purchase of receipt.inAppPurchases) {
+            if (purchase.transactionId !== undefined) {
+                return purchase.transactionId
+            }
+            if (purchase.originalTransactionId !== undefined) {
+                return purchase.originalTransactionId
+            }
+        }
+        return null
+    }
+
+    /**
+     * Orders the receipt's embedded certificates as leaf, intermediate, root and hands the leaf and the
+     * intermediate to the shared chain verification, which enforces the WWDR intermediate OID and the
+     * receipt signing leaf OID and validates to the caller-supplied Apple roots.
+     */
+    protected async verifyChain(signedData: SignedDataContent, effectiveDate: Date): Promise<KeyObject> {
+        const embedded = signedData.certificates.map(certificate => new X509Certificate(certificate))
+        const leaf = embedded.find(certificate => matchesSignerIdentifier(certificate, signedData.signerInfo))
+        if (leaf === undefined) {
+            throw new VerificationException(VerificationStatus.INVALID_CERTIFICATE, new Error("Signer certificate is not embedded in the receipt"))
+        }
+        const ordered = [leaf]
+        while (ordered.length < embedded.length) {
+            const issuer = embedded.find(candidate => !ordered.includes(candidate) && candidate.subject === ordered[ordered.length - 1].issuer)
+            if (issuer === undefined) {
+                break
+            }
+            ordered.push(issuer)
+        }
+        if (ordered.length !== EXPECTED_CHAIN_LENGTH) {
+            throw new VerificationException(VerificationStatus.INVALID_CHAIN_LENGTH)
+        }
+        return await this.chainVerifier.verifyReceiptCertificateChain(ordered[0], ordered[1], effectiveDate)
+    }
+
+    protected validateBundleId(bundleId?: string) {
+        if (this.bundleId !== bundleId) {
+            throw new VerificationException(VerificationStatus.INVALID_APP_IDENTIFIER)
+        }
+    }
+
+    protected validateEnvironment(environment?: Environment) {
+        if (this.environment !== environment) {
+            throw new VerificationException(VerificationStatus.INVALID_ENVIRONMENT)
+        }
+    }
+}
+
+/**
+ * Maps the receipt type attribute to a server environment. Only explicit production values map to
+ * {@link Environment.PRODUCTION}; unknown or missing values map to undefined and fail environment validation.
+ */
+function environmentForReceiptType(receiptType?: string): Environment | undefined {
+    switch (receiptType) {
+        case "Production":
+        case "ProductionVPP":
+            return Environment.PRODUCTION
+        case "ProductionSandbox":
+        case "ProductionVPPSandbox":
+            return Environment.SANDBOX
+        case "Xcode":
+            return Environment.XCODE
+        case "LocalTesting":
+            return Environment.LOCAL_TESTING
+        default:
+            return undefined
+    }
+}
+
+function decodeBase64Receipt(encodedReceipt: string): Buffer {
+    // Line breaks are tolerated, as base64 receipts commonly pick them up in transit
+    const stripped = encodedReceipt.replace(/\s/g, '')
+    if (stripped.length === 0 || !BASE64_REGEX.test(stripped)) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt is not valid base64"))
+    }
+    return Buffer.from(stripped, 'base64')
+}
+
+// The parts of a CMS SignedData an app receipt is verified from
+interface SignedDataContent {
+    content: Buffer
+    certificates: Buffer[]
+    signerInfo: SignerInfo
+}
+
+interface SignerInfo {
+    issuer: Buffer
+    serialNumber: Buffer
+    digestAlgorithmOid: string
+    signedAttributes?: Asn1Node
+    signature: Buffer
+}
+
+function parseSignedData(receiptDer: Buffer): SignedDataContent {
+    let contentInfo: Asn1Node
+    try {
+        // Parsing must exhaust the input, rejecting trailing bytes after the CMS blob
+        contentInfo = parseAsn1(receiptDer)
+    } catch (error) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt is not a PKCS#7 container"))
+    }
+    const outer = childrenOf(contentInfo)
+    if (contentInfo.tag !== SEQUENCE_TAG || outer.length < 2 || outer[0].tag !== OID_TAG ||
+        decodeOid(outer[0]) !== SIGNED_DATA_OID || outer[1].tag !== CONTEXT_0_TAG) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt is not a PKCS#7 container"))
+    }
+    const signedDataNode = childrenOf(outer[1])[0]
+    const signedData = signedDataNode === undefined ? [] : childrenOf(signedDataNode)
+    if (signedData.length < 4) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt is not a PKCS#7 container"))
+    }
+    const encapsulatedContentInfo = childrenOf(signedData[2])
+    if (encapsulatedContentInfo.length < 2 || encapsulatedContentInfo[1].tag !== CONTEXT_0_TAG) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt has no encapsulated payload"))
+    }
+    const contentNode = childrenOf(encapsulatedContentInfo[1])[0]
+    if (contentNode === undefined || !isOctetString(contentNode)) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt has no encapsulated payload"))
+    }
+    let certificates: Buffer[] = []
+    for (const child of signedData.slice(3, signedData.length - 1)) {
+        if (child.tag === CONTEXT_0_TAG) {
+            certificates = childrenOf(child).map(certificate => certificate.raw)
+        }
+    }
+    const signerInfos = signedData[signedData.length - 1]
+    if (signerInfos.tag !== SET_TAG || childrenOf(signerInfos).length === 0) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt has no signer info"))
+    }
+    return {
+        content: octetStringValue(contentNode),
+        certificates: certificates,
+        signerInfo: parseSignerInfo(childrenOf(signerInfos)[0])
+    }
+}
+
+function parseSignerInfo(node: Asn1Node): SignerInfo {
+    const fields = childrenOf(node)
+    if (fields.length < 5) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Malformed receipt signer info"))
+    }
+    const signerIdentifier = childrenOf(fields[1])
+    if (fields[1].tag !== SEQUENCE_TAG || signerIdentifier.length < 2) {
+        // Apple identifies the receipt signer by issuer and serial number, never by subject key identifier
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt signer is not identified by issuer and serial number"))
+    }
+    let index = 3
+    let signedAttributes: Asn1Node | undefined
+    if (fields[index].tag === CONTEXT_0_TAG) {
+        signedAttributes = fields[index]
+        index += 1
+    }
+    // The signature algorithm field is skipped: the key type is checked against the certificate and the
+    // digest algorithm drives the hash
+    index += 1
+    const digestAlgorithm = childrenOf(fields[2])[0]
+    if (fields.length <= index || digestAlgorithm === undefined) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Malformed receipt signer info"))
+    }
+    return {
+        issuer: signerIdentifier[0].raw,
+        serialNumber: signerIdentifier[1].contents,
+        digestAlgorithmOid: decodeOid(digestAlgorithm),
+        signedAttributes: signedAttributes,
+        signature: fields[index].contents
+    }
+}
+
+/**
+ * Whether the certificate is the one the signer info names, comparing the issuer name and the serial number
+ * of TBSCertificate ::= SEQUENCE { version [0] EXPLICIT, serialNumber, signature, issuer, ... }.
+ */
+function matchesSignerIdentifier(certificate: X509Certificate, signerInfo: SignerInfo): boolean {
+    const tbsCertificate = childrenOf(parseAsn1(certificate.raw))[0]
+    const fields = tbsCertificate === undefined ? [] : childrenOf(tbsCertificate)
+    // The version is an optional explicit [0] before the serial number
+    const offset = fields.length > 0 && fields[0].tag === CONTEXT_0_TAG ? 1 : 0
+    if (fields.length < offset + 3) {
+        return false
+    }
+    return fields[offset].contents.equals(signerInfo.serialNumber) && fields[offset + 2].raw.equals(signerInfo.issuer)
+}
+
+function verifySignature(signedData: SignedDataContent, signerPublicKey: KeyObject) {
+    if (signerPublicKey.asymmetricKeyType !== 'rsa') {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt signer key is not RSA"))
+    }
+    const digestAlgorithm = DIGEST_ALGORITHMS[signedData.signerInfo.digestAlgorithmOid]
+    if (digestAlgorithm === undefined) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Unrecognized receipt digest algorithm " + signedData.signerInfo.digestAlgorithmOid))
+    }
+    let signedBytes: Buffer
+    const signedAttributes = signedData.signerInfo.signedAttributes
+    if (signedAttributes !== undefined) {
+        const contentDigest = createHash(digestAlgorithm).update(signedData.content).digest()
+        const messageDigest = findMessageDigestAttribute(signedAttributes)
+        if (messageDigest === undefined || messageDigest.length !== contentDigest.length || !timingSafeEqual(messageDigest, contentDigest)) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt messageDigest attribute does not match the payload"))
+        }
+        // The signature covers the signed attributes re-encoded as an explicit SET, RFC 5652 section 5.4:
+        // swap the implicit [0] tag for a SET tag
+        signedBytes = Buffer.concat([Buffer.from([SET_TAG]), signedAttributes.raw.subarray(1)])
+    } else {
+        signedBytes = signedData.content
+    }
+    if (!verify(digestAlgorithm, signedBytes, signerPublicKey, signedData.signerInfo.signature)) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt signature does not verify"))
+    }
+}
+
+function findMessageDigestAttribute(signedAttributes: Asn1Node): Buffer | undefined {
+    for (const attribute of childrenOf(signedAttributes)) {
+        const fields = childrenOf(attribute)
+        if (fields.length >= 2 && fields[0].tag === OID_TAG && decodeOid(fields[0]) === MESSAGE_DIGEST_OID) {
+            const values = childrenOf(fields[1])
+            if (values.length === 1) {
+                return values[0].contents
+            }
+        }
+    }
+    return undefined
+}
+
+/** ReceiptAttribute ::= SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING } */
+interface ReceiptAttribute {
+    type: number
+    value: Buffer
+}
+
+function parseReceiptPayload(payload: Buffer): AppReceipt {
+    const receipt: AppReceipt = {
+        inAppPurchases: [],
+        unknownAttributes: new Map()
+    }
+    for (const attribute of parseAttributeSet(payload, "Receipt payload")) {
+        switch (attribute.type) {
+            case RECEIPT_TYPE_TYPE_ID:
+                receipt.receiptType = decodeString(attribute.value)
+                break
+            case BUNDLE_ID_TYPE_ID:
+                receipt.bundleId = decodeString(attribute.value)
+                receipt.bundleIdBytes = attribute.value
+                break
+            case APPLICATION_VERSION_TYPE_ID:
+                receipt.applicationVersion = decodeString(attribute.value)
+                break
+            case OPAQUE_VALUE_TYPE_ID:
+                receipt.opaqueValue = attribute.value
+                break
+            case SHA1_HASH_TYPE_ID:
+                receipt.sha1Hash = attribute.value
+                break
+            case RECEIPT_CREATION_DATE_TYPE_ID:
+                receipt.receiptCreationDate = decodeDate(attribute.value)
+                break
+            case IN_APP_TYPE_ID:
+                receipt.inAppPurchases.push(parseInAppPurchase(attribute.value))
+                break
+            case ORIGINAL_PURCHASE_DATE_TYPE_ID:
+                receipt.originalPurchaseDate = decodeDate(attribute.value)
+                break
+            case ORIGINAL_APPLICATION_VERSION_TYPE_ID:
+                receipt.originalApplicationVersion = decodeString(attribute.value)
+                break
+            case EXPIRATION_DATE_TYPE_ID:
+                receipt.expirationDate = decodeDate(attribute.value)
+                break
+            default:
+                recordUnknownAttribute(receipt.unknownAttributes, attribute)
+                break
+        }
+    }
+    return receipt
+}
+
+function parseInAppPurchase(inAppSet: Buffer): InAppPurchaseReceipt {
+    const purchase: InAppPurchaseReceipt = {
+        unknownAttributes: new Map()
+    }
+    for (const attribute of parseAttributeSet(inAppSet, "In-app purchase attribute")) {
+        switch (attribute.type) {
+            case QUANTITY_TYPE_ID:
+                purchase.quantity = decodeInteger(attribute.value)
+                break
+            case PRODUCT_IDENTIFIER_TYPE_ID:
+                purchase.productId = decodeString(attribute.value)
+                break
+            case TRANSACTION_IDENTIFIER_TYPE_ID:
+                purchase.transactionId = decodeString(attribute.value)
+                break
+            case PURCHASE_DATE_TYPE_ID:
+                purchase.purchaseDate = decodeDate(attribute.value)
+                break
+            case ORIGINAL_TRANSACTION_IDENTIFIER_TYPE_ID:
+                purchase.originalTransactionId = decodeString(attribute.value)
+                break
+            case IN_APP_ORIGINAL_PURCHASE_DATE_TYPE_ID:
+                purchase.originalPurchaseDate = decodeDate(attribute.value)
+                break
+            case EXPIRES_DATE_TYPE_ID:
+                purchase.expiresDate = decodeDate(attribute.value)
+                break
+            case WEB_ORDER_LINE_ITEM_IDENTIFIER_TYPE_ID:
+                purchase.webOrderLineItemId = decodeInteger(attribute.value)
+                break
+            case CANCELLATION_DATE_TYPE_ID:
+                purchase.cancellationDate = decodeDate(attribute.value)
+                break
+            case IS_IN_INTRO_OFFER_PERIOD_TYPE_ID:
+                purchase.isInIntroOfferPeriod = decodeInteger(attribute.value) !== 0
+                break
+            default:
+                recordUnknownAttribute(purchase.unknownAttributes, attribute)
+                break
+        }
+    }
+    return purchase
+}
+
+function recordUnknownAttribute(unknownAttributes: Map<number, Buffer[]>, attribute: ReceiptAttribute) {
+    const values = unknownAttributes.get(attribute.type)
+    if (values === undefined) {
+        unknownAttributes.set(attribute.type, [attribute.value])
+    } else {
+        values.push(attribute.value)
+    }
+}
+
+function parseAttributeSet(der: Buffer, what: string): ReceiptAttribute[] {
+    let node = parseAttributeSetNode(der, what)
+    if (isOctetString(node)) {
+        // Xcode receipts double-wrap the payload in an extra OCTET STRING; ReceiptUtility handles the same shape
+        node = parseAttributeSetNode(octetStringValue(node), what)
+    }
+    if (node.tag !== SET_TAG) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error(what + " is not an ASN.1 SET"))
+    }
+    const attributes: ReceiptAttribute[] = []
+    for (const child of childrenOf(node)) {
+        const fields = childrenOf(child)
+        if (child.tag !== SEQUENCE_TAG || fields.length < 3 || fields[0].tag !== INTEGER_TAG || !isOctetString(fields[2])) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Malformed receipt attribute"))
+        }
+        attributes.push({
+            type: integerValue(fields[0]),
+            value: octetStringValue(fields[2])
+        })
+    }
+    return attributes
+}
+
+function parseAttributeSetNode(der: Buffer, what: string): Asn1Node {
+    try {
+        return parseAsn1(der)
+    } catch (error) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error(what + " is not valid ASN.1"))
+    }
+}
+
+function decodeAttributeValue(der: Buffer): Asn1Node {
+    try {
+        return parseAsn1(der)
+    } catch (error) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Attribute value is not valid ASN.1"))
+    }
+}
+
+function decodeString(der: Buffer): string {
+    const node = decodeAttributeValue(der)
+    if (node.tag !== UTF8_STRING_TAG && node.tag !== IA5_STRING_TAG && node.tag !== PRINTABLE_STRING_TAG) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Attribute value is not an ASN.1 string"))
+    }
+    return node.contents.toString('utf8')
+}
+
+function decodeInteger(der: Buffer): number {
+    const node = decodeAttributeValue(der)
+    if (node.tag !== INTEGER_TAG) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Attribute value is not an ASN.1 integer"))
+    }
+    return integerValue(node)
+}
+
+/** RFC 3339 date in an IA5String, returned in milliseconds; empty means absent, as real receipts encode it. */
+function decodeDate(der: Buffer): number | undefined {
+    const text = decodeString(der)
+    if (text.length === 0) {
+        return undefined
+    }
+    const parsed = new Date(text)
+    if (!RFC_3339_REGEX.test(text) || isNaN(parsed.getTime())) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Unparseable receipt date: " + text))
+    }
+    return parsed.getTime()
+}
+
+/** Non-negative and within the safe integer range; real receipts carry 7-byte integers. */
+function integerValue(node: Asn1Node): number {
+    if (node.contents.length === 0 || node.contents[0] >= 0x80) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt integer out of range"))
+    }
+    let value = 0n
+    for (const byte of node.contents) {
+        value = value * 256n + BigInt(byte)
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt integer out of range"))
+    }
+    return Number(value)
+}
+
+// A minimal DER/BER reader. jsrsasign's ASN1HEX only walks definite length encoding, while genuine Xcode
+// receipts use indefinite length encoding throughout, and verification additionally needs the exact byte
+// ranges of the values it hashes and of the certificates it validates.
+
+const INTEGER_TAG = 0x02;
+const OCTET_STRING_TAG = 0x04;
+const OID_TAG = 0x06;
+const UTF8_STRING_TAG = 0x0c;
+const PRINTABLE_STRING_TAG = 0x13;
+const IA5_STRING_TAG = 0x16;
+const SEQUENCE_TAG = 0x30;
+const SET_TAG = 0x31;
+const CONTEXT_0_TAG = 0xa0;
+const CONSTRUCTED_OCTET_STRING_TAG = 0x24;
+
+const MAXIMUM_ASN1_DEPTH = 32;
+
+interface Asn1Node {
+    tag: number
+    /** The complete tag-length-value slice */
+    raw: Buffer
+    /** The value bytes, the concatenated children of an indefinite length value */
+    contents: Buffer
+    children?: Asn1Node[]
+}
+
+/** Parses a single ASN.1 value, requiring it to consume the whole buffer. */
+function parseAsn1(der: Buffer): Asn1Node {
+    const [node, end] = readAsn1Node(der, 0, 0)
+    if (end !== der.length) {
+        throw new Error("Trailing bytes after the ASN.1 value")
+    }
+    return node
+}
+
+function readAsn1Node(der: Buffer, offset: number, depth: number): [Asn1Node, number] {
+    if (depth > MAXIMUM_ASN1_DEPTH) {
+        throw new Error("Maximum ASN.1 nesting depth exceeded")
+    }
+    if (offset + 2 > der.length) {
+        throw new Error("Truncated ASN.1 value")
+    }
+    const tag = der[offset]
+    if ((tag & 0x1f) === 0x1f) {
+        throw new Error("Multi-byte ASN.1 tags are not supported")
+    }
+    const constructed = (tag & 0x20) !== 0
+    let position = offset + 1
+    const lengthByte = der[position]
+    position += 1
+    if (lengthByte === 0x80) {
+        if (!constructed) {
+            throw new Error("Indefinite length on a primitive ASN.1 value")
+        }
+        const children: Asn1Node[] = []
+        while (true) {
+            if (position + 2 > der.length) {
+                throw new Error("Unterminated indefinite length ASN.1 value")
+            }
+            if (der[position] === 0x00 && der[position + 1] === 0x00) {
+                position += 2
+                break
+            }
+            const [child, next] = readAsn1Node(der, position, depth + 1)
+            children.push(child)
+            position = next
+        }
+        return [{
+            tag: tag,
+            raw: der.subarray(offset, position),
+            contents: Buffer.concat(children.map(child => child.raw)),
+            children: children
+        }, position]
+    }
+    let length = lengthByte
+    if (lengthByte > 0x80) {
+        const lengthBytes = lengthByte & 0x7f
+        if (lengthBytes > 4 || position + lengthBytes > der.length) {
+            throw new Error("Unsupported ASN.1 length")
+        }
+        length = 0
+        for (let i = 0; i < lengthBytes; i++) {
+            length = length * 256 + der[position + i]
+        }
+        position += lengthBytes
+    }
+    const end = position + length
+    if (end > der.length) {
+        throw new Error("ASN.1 length exceeds the input")
+    }
+    const node: Asn1Node = {
+        tag: tag,
+        raw: der.subarray(offset, end),
+        contents: der.subarray(position, end)
+    }
+    if (constructed) {
+        node.children = readAsn1Children(node.contents, depth + 1)
+    }
+    return [node, end]
+}
+
+function readAsn1Children(contents: Buffer, depth: number): Asn1Node[] {
+    const children: Asn1Node[] = []
+    let position = 0
+    while (position < contents.length) {
+        const [child, next] = readAsn1Node(contents, position, depth)
+        children.push(child)
+        position = next
+    }
+    return children
+}
+
+function childrenOf(node: Asn1Node): Asn1Node[] {
+    return node.children === undefined ? [] : node.children
+}
+
+function isOctetString(node: Asn1Node): boolean {
+    return node.tag === OCTET_STRING_TAG || node.tag === CONSTRUCTED_OCTET_STRING_TAG
+}
+
+/** The value bytes of an OCTET STRING, joining the chunks of a constructed one. */
+function octetStringValue(node: Asn1Node): Buffer {
+    if (node.children === undefined) {
+        return node.contents
+    }
+    return Buffer.concat(node.children.map(child => octetStringValue(child)))
+}
+
+function decodeOid(node: Asn1Node): string {
+    if (node.tag !== OID_TAG || node.contents.length === 0) {
+        throw new Error("Not an ASN.1 object identifier")
+    }
+    const components = [Math.floor(node.contents[0] / 40), node.contents[0] % 40]
+    let value = 0
+    for (const byte of node.contents.subarray(1)) {
+        value = value * 128 + (byte & 0x7f)
+        if ((byte & 0x80) === 0) {
+            components.push(value)
+            value = 0
+        }
+    }
+    return components.join('.')
+}

--- a/app_receipt_verification.ts
+++ b/app_receipt_verification.ts
@@ -42,6 +42,11 @@ const DIGEST_ALGORITHMS: { [index: string]: string } = {
 // Leaf, intermediate and root, the same chain length the JWS x5c header claim carries
 const EXPECTED_CHAIN_LENGTH = 3;
 
+// Bounds on what is decoded before the receipt has been verified, so that a hostile receipt cannot make
+// parsing expensive: an integer wide enough to hold any receipt value, and the certificates a chain can hold
+const MAXIMUM_INTEGER_BYTES = 8;
+const MAXIMUM_EMBEDDED_CERTIFICATES = 10;
+
 const BASE64_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
 // RFC 3339, the format receipt date attributes carry
 const RFC_3339_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/
@@ -166,6 +171,12 @@ export class AppReceiptVerifier {
      * receipt signing leaf OID and validates to the caller-supplied Apple roots.
      */
     protected async verifyChain(signedData: SignedDataContent, effectiveDate: Date): Promise<KeyObject> {
+        // The embedded certificates are attacker-supplied and are ordered into a chain below, before anything
+        // about the receipt has been verified, so a receipt carrying more of them than a chain can hold is
+        // rejected here rather than assembled.
+        if (signedData.certificates.length > MAXIMUM_EMBEDDED_CERTIFICATES) {
+            throw new VerificationException(VerificationStatus.INVALID_CHAIN_LENGTH)
+        }
         const embedded = signedData.certificates.map(certificate => new X509Certificate(certificate))
         const leaf = embedded.find(certificate => matchesSignerIdentifier(certificate, signedData.signerInfo))
         if (leaf === undefined) {
@@ -546,19 +557,23 @@ function decodeDate(der: Buffer): number | undefined {
     return parsed.getTime()
 }
 
-/** Non-negative and within the safe integer range; real receipts carry 7-byte integers. */
+/**
+ * Non-negative and within the safe integer range; real receipts carry 7-byte integers. The width is rejected
+ * before the value is accumulated rather than after, because attribute types reach this before anything about
+ * the receipt has been verified.
+ */
 function integerValue(node: Asn1Node): number {
-    if (node.contents.length === 0 || node.contents[0] >= 0x80) {
+    if (node.contents.length === 0 || node.contents.length > MAXIMUM_INTEGER_BYTES || node.contents[0] >= 0x80) {
         throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt integer out of range"))
     }
-    let value = 0n
+    let value = 0
     for (const byte of node.contents) {
-        value = value * 256n + BigInt(byte)
+        value = value * 256 + byte
     }
-    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    if (value > Number.MAX_SAFE_INTEGER) {
         throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, new Error("Receipt integer out of range"))
     }
-    return Number(value)
+    return value
 }
 
 // A minimal DER/BER reader. jsrsasign's ASN1HEX only walks definite length encoding, while genuine Xcode

--- a/index.ts
+++ b/index.ts
@@ -32,9 +32,11 @@ import { Validator } from './models/Validator';
 import { Status } from './models/Status';
 export { SignedDataVerifier, VerificationException, VerificationStatus } from './jws_verification'
 export { ReceiptUtility } from './receipt_utility'
+export { AppReceiptVerifier } from './app_receipt_verification'
 export { AccountTenure } from "./models/AccountTenure"
 export { AlternateProduct } from './models/AlternateProduct'
 export { AppData } from './models/AppData'
+export { AppReceipt } from './models/AppReceipt'
 export { AppTransactionInfoResponse } from './models/AppTransactionInfoResponse';
 export { AutoRenewStatus } from './models/AutoRenewStatus'
 export { BulletPoint } from './models/BulletPoint'
@@ -65,6 +67,7 @@ export { HistoryResponse } from './models/HistoryResponse'
 export { ImageState } from './models/ImageState'
 export { ImageSize } from './models/ImageSize'
 export { InAppOwnershipType } from './models/InAppOwnershipType'
+export { InAppPurchaseReceipt } from './models/InAppPurchaseReceipt'
 export { JWSRenewalInfoDecodedPayload } from './models/JWSRenewalInfoDecodedPayload'
 export { JWSTransactionDecodedPayload } from './models/JWSTransactionDecodedPayload'
 export { LastTransactionsItem } from './models/LastTransactionsItem'

--- a/models/AppReceipt.ts
+++ b/models/AppReceipt.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import { InAppPurchaseReceipt } from "./InAppPurchaseReceipt"
+
+/**
+ * A decoded legacy App Store receipt (the PKCS#7 app receipt).
+ *
+ * {@link https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt receipt}
+ */
+export interface AppReceipt {
+
+    /**
+     * The raw receipt type, e.g. Production, ProductionVPP, ProductionSandbox, ProductionVPPSandbox or Xcode.
+     */
+    receiptType?: string
+
+    /**
+     * The bundle identifier of the app the receipt belongs to.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/bundleid bundleId}
+     */
+    bundleId?: string
+
+    /**
+     * The raw ASN.1 bytes of the bundle identifier attribute, needed together with the opaque value and the
+     * SHA-1 hash to compute the device-hash binding described in Apple's receipt validation guide.
+     */
+    bundleIdBytes?: Buffer
+
+    /**
+     * The app's version number.
+     *
+     * {@link https://developer.apple.com/documentation/storekit/apptransaction/appversion appVersion}
+     */
+    applicationVersion?: string
+
+    /**
+     * An opaque value used, with other data, to compute the device hash.
+     */
+    opaqueValue?: Buffer
+
+    /**
+     * The SHA-1 device-hash attribute of the receipt.
+     */
+    sha1Hash?: Buffer
+
+    /**
+     * The time the App Store generated the receipt, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/receiptcreationdate receiptCreationDate}
+     */
+    receiptCreationDate?: number
+
+    /**
+     * The time of the original app purchase, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/originalpurchasedate originalPurchaseDate}
+     */
+    originalPurchaseDate?: number
+
+    /**
+     * The version of the app that the user originally purchased.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/originalapplicationversion originalAppVersion}
+     */
+    originalApplicationVersion?: string
+
+    /**
+     * The expiration date of the receipt, in UNIX time, in milliseconds.
+     * Present for apps purchased through the Volume Purchase Program.
+     */
+    expirationDate?: number
+
+    /**
+     * The decoded in-app purchase attributes contained in the receipt.
+     *
+     * {@link https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app in_app}
+     */
+    inAppPurchases: InAppPurchaseReceipt[]
+
+    /**
+     * Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+     * so fields Apple adds later remain accessible without a library update.
+     */
+    unknownAttributes: Map<number, Buffer[]>
+}

--- a/models/InAppPurchaseReceipt.ts
+++ b/models/InAppPurchaseReceipt.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+/**
+ * A decoded in-app purchase attribute from a legacy App Store receipt.
+ *
+ * {@link https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app in_app}
+ */
+export interface InAppPurchaseReceipt {
+
+    /**
+     * The number of items purchased.
+     *
+     * {@link https://developer.apple.com/documentation/appstorereceipts/quantity quantity}
+     */
+    quantity?: number
+
+    /**
+     * The unique identifier of the product purchased.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/productid productId}
+     */
+    productId?: string
+
+    /**
+     * The unique identifier of the transaction.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/transactionid transactionId}
+     */
+    transactionId?: string
+
+    /**
+     * The unique identifier of the original transaction.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/originaltransactionid originalTransactionId}
+     */
+    originalTransactionId?: string
+
+    /**
+     * The time of the purchase, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/purchasedate purchaseDate}
+     */
+    purchaseDate?: number
+
+    /**
+     * The time of the original purchase, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/originalpurchasedate originalPurchaseDate}
+     */
+    originalPurchaseDate?: number
+
+    /**
+     * The expiration time of the subscription, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/expiresdate expiresDate}
+     */
+    expiresDate?: number
+
+    /**
+     * The time Apple customer support canceled the transaction or the subscription was upgraded, in UNIX time, in milliseconds.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/revocationdate revocationDate}
+     */
+    cancellationDate?: number
+
+    /**
+     * The unique identifier of subscription purchase events across devices, including subscription renewals.
+     *
+     * {@link https://developer.apple.com/documentation/appstoreserverapi/weborderlineitemid webOrderLineItemId}
+     */
+    webOrderLineItemId?: number
+
+    /**
+     * Whether the subscription is in an introductory offer period.
+     *
+     * {@link https://developer.apple.com/documentation/appstorereceipts/is_in_intro_offer_period is_in_intro_offer_period}
+     */
+    isInIntroOfferPeriod?: boolean
+
+    /**
+     * Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+     * so fields Apple adds later remain accessible without a library update.
+     */
+    unknownAttributes: Map<number, Buffer[]>
+}

--- a/receipt_utility.ts
+++ b/receipt_utility.ts
@@ -11,6 +11,7 @@ export class ReceiptUtility {
     /**
      * Extracts a transaction id from an encoded App Receipt. Throws if the receipt does not match the expected format.
      * *NO validation* is performed on the receipt, and any data returned should only be used to call the App Store Server API.
+     * To verify the receipt's signature before extraction, use {@link AppReceiptVerifier.verifyAndExtractTransactionId}.
      * @param appReceipt The unmodified app receipt
      * @returns A transaction id from the array of in-app purchases, null if the receipt contains no in-app purchases
      */

--- a/tests/receipt_creator.ts
+++ b/tests/receipt_creator.ts
@@ -67,17 +67,26 @@ export class ReceiptCreator {
      * @param embeddedCertificates How many certificates of the chain, starting at the leaf, to embed in the container
      * @param signingTime The CMS signing time attribute, which an old receipt signed by a since expired
      *                    certificate needs set to its original signing time
+     * @param digest The digest the signer names and signs with, e.g. one Apple does not use
+     * @param paddingCertificates Unrelated certificates embedded on top of the chain, as a receipt bloated to
+     *                            make chain assembly expensive carries
      */
-    signReceipt(payload: Buffer, embeddedCertificates: number = this.chain.length, signingTime: Date = new Date()): Buffer {
+    signReceipt(payload: Buffer, embeddedCertificates: number = this.chain.length, signingTime: Date = new Date(), digest: string = "sha256", paddingCertificates: number = 0): Buffer {
+        const certificates = this.chain.slice(0, embeddedCertificates)
+        for (let i = 0; i < paddingCertificates; i++) {
+            const keyPair = rsaKeyPair()
+            // Carries the intermediate's subject name, so it stays a candidate at every step of chain assembly
+            certificates.push(certificate("Test WWDR CA", keyPair.publicKey, "Test WWDR CA", keyPair.privateKey, true, undefined, daysAgo(3650), inOneYear()))
+        }
         const signedData = new KJUR.asn1.cms.SignedData({
             econtent: {
                 type: "data",
                 content: { hex: payload.toString('hex') }
             },
-            certs: this.chain.slice(0, embeddedCertificates),
+            certs: certificates,
             sinfos: [{
                 id: { type: "isssn", cert: this.chain[0] },
-                hashalg: "sha256",
+                hashalg: digest,
                 sattrs: {
                     array: [
                         { attr: "contentType" },
@@ -85,7 +94,7 @@ export class ReceiptCreator {
                         { attr: "messageDigest" }
                     ]
                 },
-                sigalg: SIGNATURE_ALGORITHM,
+                sigalg: digest.toUpperCase() + "withRSA",
                 signkey: this.signingKey
             }]
         } as any)
@@ -123,6 +132,16 @@ export class ReceiptCreator {
 
     static attributeSet(): AttributeSet {
         return new AttributeSet()
+    }
+
+    /**
+     * A payload whose single attribute declares an integer type wider than any value a receipt carries, the
+     * shape a receipt takes when it is built to make integer decoding expensive rather than to be read.
+     */
+    static payloadWithOversizedAttributeType(byteLength: number): Buffer {
+        const wideType = derTlvHex(0x02, "01" + "00".repeat(byteLength - 1))
+        const attribute = derTlvHex(0x30, wideType + derTlvHex(0x02, "01") + derTlvHex(0x04, ""))
+        return Buffer.from(derTlvHex(0x31, attribute), 'hex')
     }
 
     /** The extra OCTET STRING wrapper Xcode-generated receipts put around the payload. */

--- a/tests/receipt_creator.ts
+++ b/tests/receipt_creator.ts
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import { X509Certificate, generateKeyPairSync, sign } from 'crypto';
+import { KJUR, X509 } from 'jsrsasign';
+
+const WWDR_INTERMEDIATE_OID = "1.2.840.113635.100.6.2.1";
+const RECEIPT_SIGNER_OID = "1.2.840.113635.100.6.11.1";
+const SIGNATURE_ALGORITHM = "SHA256withRSA";
+const DAY_IN_MILLIS = 86_400_000;
+
+let serialNumber = 1
+
+/**
+ * Generates a throwaway "Apple-like" RSA PKI (root, WWDR intermediate, receipt signing leaf) and CMS-signs
+ * synthetic legacy app receipts with it, so {@link AppReceiptVerifier} can be exercised without any real
+ * Apple key material or a checked-in receipt.
+ */
+export class ReceiptCreator {
+
+    /** Leaf first, then intermediate, then root; a self-signed creator holds one entry. */
+    private chain: string[]
+    private signingKey: string
+
+    private constructor(chain: string[], signingKey: string) {
+        this.chain = chain
+        this.signingKey = signingKey
+    }
+
+    /**
+     * A chain carrying both Apple marker OIDs, with a validity window wide enough to cover any plausible
+     * receipt creation date - the chain of a receipt is evaluated at the date the receipt was created, not now.
+     *
+     * @param receiptSignerOid Whether the leaf carries the receipt-signing marker OID
+     * @param wwdrIntermediateOid Whether the intermediate carries the WWDR marker OID
+     * @param notBefore The start of the validity window of every certificate in the chain
+     * @param notAfter The end of the validity window of every certificate in the chain
+     */
+    static createReceiptCreator(receiptSignerOid: boolean = true, wwdrIntermediateOid: boolean = true, notBefore: Date = daysAgo(3650), notAfter: Date = inOneYear()): ReceiptCreator {
+        const rootKeyPair = rsaKeyPair()
+        const intermediateKeyPair = rsaKeyPair()
+        const leafKeyPair = rsaKeyPair()
+        const root = certificate("Test App Store Root CA", rootKeyPair.publicKey, "Test App Store Root CA", rootKeyPair.privateKey, true, undefined, notBefore, notAfter)
+        const intermediate = certificate("Test WWDR CA", intermediateKeyPair.publicKey, "Test App Store Root CA", rootKeyPair.privateKey, true, wwdrIntermediateOid ? WWDR_INTERMEDIATE_OID : undefined, notBefore, notAfter)
+        const leaf = certificate("Test Receipt Signing", leafKeyPair.publicKey, "Test WWDR CA", intermediateKeyPair.privateKey, false, receiptSignerOid ? RECEIPT_SIGNER_OID : undefined, notBefore, notAfter)
+        return new ReceiptCreator([leaf, intermediate, root], leafKeyPair.privateKey)
+    }
+
+    /**
+     * A single self-signed certificate, as an Xcode-generated receipt carries; such a receipt is never chain
+     * verified.
+     */
+    static createSelfSignedReceiptCreator(): ReceiptCreator {
+        const keyPair = rsaKeyPair()
+        const selfSigned = certificate("Test Xcode Receipt Signing", keyPair.publicKey, "Test Xcode Receipt Signing", keyPair.privateKey, false, RECEIPT_SIGNER_OID, daysAgo(3650), inOneYear())
+        return new ReceiptCreator([selfSigned], keyPair.privateKey)
+    }
+
+    /** The root of this chain, in the form the verifier's constructor accepts. */
+    getRootCertificate(): Buffer {
+        return new X509Certificate(this.chain[this.chain.length - 1]).raw
+    }
+
+    /**
+     * CMS-signs a payload as encapsulated content, embedding the chain.
+     *
+     * @param payload The receipt payload to encapsulate
+     * @param embeddedCertificates How many certificates of the chain, starting at the leaf, to embed in the container
+     * @param signingTime The CMS signing time attribute, which an old receipt signed by a since expired
+     *                    certificate needs set to its original signing time
+     */
+    signReceipt(payload: Buffer, embeddedCertificates: number = this.chain.length, signingTime: Date = new Date()): Buffer {
+        const signedData = new KJUR.asn1.cms.SignedData({
+            econtent: {
+                type: "data",
+                content: { hex: payload.toString('hex') }
+            },
+            certs: this.chain.slice(0, embeddedCertificates),
+            sinfos: [{
+                id: { type: "isssn", cert: this.chain[0] },
+                hashalg: "sha256",
+                sattrs: {
+                    array: [
+                        { attr: "contentType" },
+                        { attr: "signingTime", str: utcTime(signingTime) },
+                        { attr: "messageDigest" }
+                    ]
+                },
+                sigalg: SIGNATURE_ALGORITHM,
+                signkey: this.signingKey
+            }]
+        } as any)
+        return Buffer.from(signedData.getContentInfoEncodedHex(), 'hex')
+    }
+
+    /**
+     * CMS-signs a payload without signed attributes, the signature over the payload directly - the shape
+     * genuine App Store receipts have, which jsrsasign's CMS generator cannot produce. The container is
+     * assembled by hand for that reason.
+     */
+    signReceiptWithoutSignedAttributes(payload: Buffer): Buffer {
+        const leaf = new X509()
+        leaf.readCertPEM(this.chain[0])
+        const sha256Algorithm = derTlvHex(0x30, derTlvHex(0x06, "608648016503040201") + "0500")
+        const rsaAlgorithm = derTlvHex(0x30, derTlvHex(0x06, "2a864886f70d010101") + "0500")
+        const signerInfo = derTlvHex(0x30,
+            derTlvHex(0x02, "01") +
+            derTlvHex(0x30, leaf.getIssuerHex() + derTlvHex(0x02, leaf.getSerialNumberHex())) +
+            sha256Algorithm +
+            rsaAlgorithm +
+            derTlvHex(0x04, sign('sha256', payload, this.signingKey).toString('hex')))
+        const encapsulatedContentInfo = derTlvHex(0x30,
+            derTlvHex(0x06, "2a864886f70d010701") +
+            derTlvHex(0xa0, derTlvHex(0x04, payload.toString('hex'))))
+        const certificates = this.chain.map(pem => new X509Certificate(pem).raw.toString('hex')).join('')
+        const signedData = derTlvHex(0x30,
+            derTlvHex(0x02, "01") +
+            derTlvHex(0x31, sha256Algorithm) +
+            encapsulatedContentInfo +
+            derTlvHex(0xa0, certificates) +
+            derTlvHex(0x31, signerInfo))
+        return Buffer.from(derTlvHex(0x30, derTlvHex(0x06, "2a864886f70d010702") + derTlvHex(0xa0, signedData)), 'hex')
+    }
+
+    static attributeSet(): AttributeSet {
+        return new AttributeSet()
+    }
+
+    /** The extra OCTET STRING wrapper Xcode-generated receipts put around the payload. */
+    static doubleWrap(payload: Buffer): Buffer {
+        return derBytes(new KJUR.asn1.DEROctetString({ hex: payload.toString('hex') }))
+    }
+}
+
+/**
+ * Builds a receipt attribute SET, the shape both the receipt payload and the value of an in-app purchase
+ * attribute take. Each attribute is SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }.
+ */
+export class AttributeSet {
+    private attributes: any[] = []
+
+    /** An attribute whose value is a DER UTF8String, e.g. the bundle identifier. */
+    string(type: number, value: string): AttributeSet {
+        return this.raw(type, derBytes(new KJUR.asn1.DERUTF8String({ str: value })))
+    }
+
+    /** An attribute whose value is a DER IA5String holding an RFC 3339 date. */
+    date(type: number, value: string): AttributeSet {
+        return this.raw(type, derBytes(new KJUR.asn1.DERIA5String({ str: value })))
+    }
+
+    /** An attribute whose value is a DER INTEGER, e.g. a purchase quantity. */
+    integer(type: number, value: number): AttributeSet {
+        return this.raw(type, derBytes(new KJUR.asn1.DERInteger({ int: value })))
+    }
+
+    /** An attribute whose value bytes are used as-is, e.g. an opaque value or a nested SET. */
+    raw(type: number, value: Buffer): AttributeSet {
+        this.attributes.push(new KJUR.asn1.DERSequence({
+            array: [
+                new KJUR.asn1.DERInteger({ int: type }),
+                new KJUR.asn1.DERInteger({ int: 1 }),
+                new KJUR.asn1.DEROctetString({ hex: value.toString('hex') })
+            ]
+        } as any))
+        return this
+    }
+
+    /**
+     * The attributes are left in insertion order rather than sorted into DER canonical order, so that a test
+     * can assert on the order of the in-app purchases it put in.
+     */
+    build(): Buffer {
+        return derBytes(new KJUR.asn1.DERSet({ array: this.attributes, sortflag: false } as any))
+    }
+}
+
+// The bundled type declarations leave the DER string and structured classes off ASN1Object, so the encoder
+// entry point they all share is reached untyped
+function derBytes(object: any): Buffer {
+    return Buffer.from(object.getEncodedHex(), 'hex')
+}
+
+/** A DER TLV from a tag byte and the hex of its content. */
+function derTlvHex(tag: number, contentHex: string): string {
+    const length = contentHex.length / 2
+    let lengthHex: string
+    if (length < 0x80) {
+        lengthHex = length.toString(16).padStart(2, '0')
+    } else {
+        let hex = length.toString(16)
+        if (hex.length % 2 === 1) {
+            hex = '0' + hex
+        }
+        lengthHex = (0x80 + hex.length / 2).toString(16) + hex
+    }
+    return tag.toString(16).padStart(2, '0') + lengthHex + contentHex
+}
+
+function rsaKeyPair(): { publicKey: string, privateKey: string } {
+    return generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+    })
+}
+
+function certificate(subject: string, subjectPublicKey: string, issuer: string, issuerPrivateKey: string, certificateAuthority: boolean, markerOid: string | undefined, notBefore: Date, notAfter: Date): string {
+    const extensions: any[] = [{ extname: "basicConstraints", cA: certificateAuthority, critical: true }]
+    if (markerOid !== undefined) {
+        // The Apple marker extensions are non-critical and carry no value
+        extensions.push({ extname: markerOid, critical: false, extn: { null: '' } })
+    }
+    const tbsCertificate = new KJUR.asn1.x509.TBSCertificate({
+        version: 3,
+        serial: { int: serialNumber++ },
+        issuer: { str: "/CN=" + issuer },
+        subject: { str: "/CN=" + subject },
+        notbefore: utcTime(notBefore),
+        notafter: utcTime(notAfter),
+        sbjpubkey: subjectPublicKey,
+        ext: extensions,
+        sigalg: SIGNATURE_ALGORITHM
+    } as any)
+    // Signed with the platform RSA implementation rather than the pure JavaScript one, which is an order of
+    // magnitude slower under the test runner
+    const signature = sign('sha256', derBytes(tbsCertificate), issuerPrivateKey)
+    return new KJUR.asn1.x509.Certificate({
+        tbsobj: tbsCertificate,
+        sigalg: SIGNATURE_ALGORITHM,
+        sighex: signature.toString('hex')
+    } as any).getPEM()
+}
+
+/** A UTCTime, YYMMDDHHMMSSZ, the encoding X.509 uses for dates before 2050. */
+function utcTime(date: Date): string {
+    return date.toISOString().replace(/^\d\d(\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d).*$/, '$1$2$3$4$5$6') + 'Z'
+}
+
+export function daysAgo(days: number): Date {
+    return new Date(new Date().getTime() - days * DAY_IN_MILLIS)
+}
+
+export function inOneYear(): Date {
+    return new Date(new Date().getTime() + 365 * DAY_IN_MILLIS)
+}

--- a/tests/unit-tests/app_receipt_verification.test.ts
+++ b/tests/unit-tests/app_receipt_verification.test.ts
@@ -302,6 +302,47 @@ describe('App Receipt Verification Checks', () => {
         expect(await verifier.verifyAndExtractTransactionId(readFile('tests/resources/xcode/xcode-app-receipt-empty'))).toBeNull()
     })
 
+    // The embedded certificates are attacker-supplied and are ordered into a chain before anything about the
+    // receipt has been verified, so a receipt carrying more of them than a chain can hold is rejected
+    it('should fail to verify a receipt embedding more certificates than a chain can hold', async () => {
+        const padded = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 3, new Date(), "sha256", 30)
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(padded)), VerificationStatus.INVALID_CHAIN_LENGTH)
+    })
+
+    // Attribute types are decoded before the receipt has been verified, so an integer wider than any value a
+    // receipt carries is rejected on its width rather than accumulated and then range checked
+    it('should fail to verify a receipt declaring an oversized attribute type', async () => {
+        const oversized = receiptCreator.signReceipt(ReceiptCreator.payloadWithOversizedAttributeType(100_000))
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(oversized)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    // A correctly signed receipt still fails when the signer names a digest outside the allowlist, so the
+    // accepted algorithms never widen to whatever a signer proposes
+    it('should fail to verify a receipt signed with a digest Apple does not use', async () => {
+        const sha512Receipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 3, new Date(), "sha512")
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(sha512Receipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    // As with an Xcode receipt, LocalTesting data is not signed by the App Store
+    it('should decode a LocalTesting receipt', async () => {
+        const receipt = xcodeCreator.signReceipt(receiptPayload("LocalTesting", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        const verifier = getReceiptVerifier(xcodeCreator, Environment.LOCAL_TESTING, BUNDLE_ID, false)
+        const decoded = await verifier.verifyAndDecodeAppReceipt(encode(receipt))
+
+        expect(decoded.receiptType).toBe("LocalTesting")
+        expect(decoded.bundleId).toBe(BUNDLE_ID)
+    })
+
+    // Skipping the signature checks must not skip the app identity check
+    it('should fail to verify a LocalTesting receipt with the wrong bundle id', async () => {
+        const receipt = xcodeCreator.signReceipt(receiptPayload("LocalTesting", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        const verifier = getReceiptVerifier(xcodeCreator, Environment.LOCAL_TESTING, "com.example.other", false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(receipt)), VerificationStatus.INVALID_APP_IDENTIFIER)
+    })
+
     it('should extract a transaction id from a verified receipt', async () => {
         const transactionId = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(sandboxReceipt))
         expect(transactionId).toBe(CONSUMABLE_TRANSACTION_ID)

--- a/tests/unit-tests/app_receipt_verification.test.ts
+++ b/tests/unit-tests/app_receipt_verification.test.ts
@@ -1,0 +1,391 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import assert = require("assert");
+import { AppReceiptVerifier } from "../../app_receipt_verification";
+import { VerificationException, VerificationStatus } from "../../jws_verification";
+import { Environment } from "../../models/Environment";
+import { ReceiptCreator, daysAgo, inOneYear } from "../receipt_creator";
+import { readFile } from "../util";
+
+const BUNDLE_ID = "com.example";
+const XCODE_FIXTURE_BUNDLE_ID = "com.example.naturelab.backyardbirds.example";
+const OTHER_BUNDLE_ID = "com.example.other";
+const APP_VERSION = "1.2.3";
+const ORIGINAL_APP_VERSION = "1.0";
+const OPAQUE_VALUE = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+const SHA1_HASH = Buffer.from("a1b2c3d4e5f60718293a4b5c6d7e8f9011223344", 'hex');
+const UNKNOWN_RECEIPT_ATTRIBUTE_VALUE = Buffer.from([0x0d, 0x0e, 0x0a, 0x0d]);
+const UNKNOWN_IN_APP_ATTRIBUTE_VALUE = Buffer.from([0x0b, 0x0e, 0x0e, 0x0f]);
+
+const RECEIPT_CREATION_DATE = "2024-03-01T12:00:00Z";
+const RECEIPT_CREATION_DATE_MILLIS = 1709294400000;
+const ORIGINAL_PURCHASE_DATE = "2023-11-15T08:30:00Z";
+const ORIGINAL_PURCHASE_DATE_MILLIS = 1700037000000;
+const EXPIRATION_DATE = "2030-01-01T00:00:00Z";
+const EXPIRATION_DATE_MILLIS = 1893456000000;
+
+const CONSUMABLE_PRODUCT_ID = "com.example.coins";
+const CONSUMABLE_TRANSACTION_ID = "70000000000001";
+const CONSUMABLE_PURCHASE_DATE = "2024-01-15T12:00:00Z";
+const CONSUMABLE_PURCHASE_DATE_MILLIS = 1705320000000;
+const CONSUMABLE_ORIGINAL_PURCHASE_DATE = "2024-01-10T09:00:00Z";
+const CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS = 1704877200000;
+
+const SUBSCRIPTION_PRODUCT_ID = "com.example.subscription";
+const SUBSCRIPTION_TRANSACTION_ID = "70000000000002";
+const SUBSCRIPTION_PURCHASE_DATE = "2024-02-01T09:30:00Z";
+const SUBSCRIPTION_PURCHASE_DATE_MILLIS = 1706779800000;
+const SUBSCRIPTION_EXPIRES_DATE = "2030-02-01T09:30:00Z";
+const SUBSCRIPTION_EXPIRES_DATE_MILLIS = 1896168600000;
+const SUBSCRIPTION_CANCELLATION_DATE = "2024-06-01T00:00:00Z";
+const SUBSCRIPTION_CANCELLATION_DATE_MILLIS = 1717200000000;
+
+// Generating six throwaway RSA PKIs and CMS-signing their receipts costs seconds, so every receipt a test
+// reads is built once here rather than per test
+const SETUP_TIMEOUT = 300_000;
+
+let receiptCreator: ReceiptCreator
+let sandboxReceipt: Buffer
+let productionReceipt: Buffer
+let unknownReceiptTypeReceipt: Buffer
+let withoutRootCertificateReceipt: Buffer
+let withoutInAppPurchasesReceipt: Buffer
+let withoutSignedAttributesReceipt: Buffer
+
+let foreignCreator: ReceiptCreator
+let foreignReceipt: Buffer
+
+let withoutReceiptSignerOidCreator: ReceiptCreator
+let withoutReceiptSignerOidReceipt: Buffer
+
+let withoutWwdrOidCreator: ReceiptCreator
+let withoutWwdrOidReceipt: Buffer
+
+let expiredCreator: ReceiptCreator
+let expiredChainReceipt: Buffer
+let expiredChainCreationDate: Date
+
+let xcodeCreator: ReceiptCreator
+let xcodeReceipt: Buffer
+let xcodeProductionReceipt: Buffer
+
+beforeAll(() => {
+    receiptCreator = ReceiptCreator.createReceiptCreator()
+    sandboxReceipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+    productionReceipt = receiptCreator.signReceipt(receiptPayload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE))
+    unknownReceiptTypeReceipt = receiptCreator.signReceipt(receiptPayload("ProductionInternal", BUNDLE_ID, RECEIPT_CREATION_DATE))
+    withoutRootCertificateReceipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 2)
+    withoutInAppPurchasesReceipt = receiptCreator.signReceipt(ReceiptCreator.attributeSet()
+        .string(0, "ProductionSandbox")
+        .string(2, BUNDLE_ID)
+        .date(12, RECEIPT_CREATION_DATE)
+        .build())
+    withoutSignedAttributesReceipt = receiptCreator.signReceiptWithoutSignedAttributes(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+    foreignCreator = ReceiptCreator.createReceiptCreator()
+    foreignReceipt = foreignCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+    withoutReceiptSignerOidCreator = ReceiptCreator.createReceiptCreator(false, true, daysAgo(3650), inOneYear())
+    withoutReceiptSignerOidReceipt = withoutReceiptSignerOidCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+    withoutWwdrOidCreator = ReceiptCreator.createReceiptCreator(true, false, daysAgo(3650), inOneYear())
+    withoutWwdrOidReceipt = withoutWwdrOidCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+    expiredCreator = ReceiptCreator.createReceiptCreator(true, true, daysAgo(730), daysAgo(365))
+    expiredChainCreationDate = truncateToSeconds(daysAgo(547))
+    expiredChainReceipt = expiredCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, expiredChainCreationDate.toISOString()), 3, expiredChainCreationDate)
+
+    xcodeCreator = ReceiptCreator.createSelfSignedReceiptCreator()
+    xcodeReceipt = xcodeCreator.signReceipt(ReceiptCreator.doubleWrap(receiptPayload("Xcode", BUNDLE_ID, RECEIPT_CREATION_DATE)))
+    xcodeProductionReceipt = xcodeCreator.signReceipt(ReceiptCreator.doubleWrap(receiptPayload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE)))
+}, SETUP_TIMEOUT)
+
+describe('App Receipt Verification Checks', () => {
+    it('should decode every attribute of a verified receipt', async () => {
+        const receipt = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt))
+
+        expect(receipt.receiptType).toBe("ProductionSandbox")
+        expect(receipt.bundleId).toBe(BUNDLE_ID)
+        // The raw bytes of the attribute are the DER UTF8String, which the device hash is computed over
+        expect(receipt.bundleIdBytes).toEqual(Buffer.concat([Buffer.from([0x0c, BUNDLE_ID.length]), Buffer.from(BUNDLE_ID)]))
+        expect(receipt.applicationVersion).toBe(APP_VERSION)
+        expect(receipt.originalApplicationVersion).toBe(ORIGINAL_APP_VERSION)
+        expect(receipt.opaqueValue).toEqual(OPAQUE_VALUE)
+        expect(receipt.sha1Hash).toEqual(SHA1_HASH)
+        expect(receipt.receiptCreationDate).toBe(RECEIPT_CREATION_DATE_MILLIS)
+        expect(receipt.originalPurchaseDate).toBe(ORIGINAL_PURCHASE_DATE_MILLIS)
+        expect(receipt.expirationDate).toBe(EXPIRATION_DATE_MILLIS)
+        expect(receipt.inAppPurchases.length).toBe(2)
+
+        const consumable = receipt.inAppPurchases[0]
+        expect(consumable.quantity).toBe(1)
+        expect(consumable.productId).toBe(CONSUMABLE_PRODUCT_ID)
+        expect(consumable.transactionId).toBe(CONSUMABLE_TRANSACTION_ID)
+        expect(consumable.originalTransactionId).toBe(CONSUMABLE_TRANSACTION_ID)
+        expect(consumable.purchaseDate).toBe(CONSUMABLE_PURCHASE_DATE_MILLIS)
+        expect(consumable.originalPurchaseDate).toBe(CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS)
+        expect(consumable.webOrderLineItemId).toBe(42)
+
+        const subscription = receipt.inAppPurchases[1]
+        expect(subscription.quantity).toBe(1)
+        expect(subscription.productId).toBe(SUBSCRIPTION_PRODUCT_ID)
+        expect(subscription.transactionId).toBe(SUBSCRIPTION_TRANSACTION_ID)
+        expect(subscription.originalTransactionId).toBe(SUBSCRIPTION_TRANSACTION_ID)
+        expect(subscription.purchaseDate).toBe(SUBSCRIPTION_PURCHASE_DATE_MILLIS)
+        expect(subscription.originalPurchaseDate).toBe(SUBSCRIPTION_PURCHASE_DATE_MILLIS)
+        expect(subscription.expiresDate).toBe(SUBSCRIPTION_EXPIRES_DATE_MILLIS)
+        expect(subscription.cancellationDate).toBe(SUBSCRIPTION_CANCELLATION_DATE_MILLIS)
+        expect(subscription.webOrderLineItemId).toBe(12345)
+    })
+
+    // An in-app purchase attribute that is present but empty means "absent", and the intro offer flag is an
+    // integer that must surface as a boolean, so a caller can distinguish "no expiration" from "expired at epoch"
+    it('should decode an empty date attribute as absent and the intro offer flag as a boolean', async () => {
+        const receipt = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt))
+
+        const consumable = receipt.inAppPurchases[0]
+        expect(consumable.isInIntroOfferPeriod).toBe(false)
+        expect(consumable.expiresDate).toBeUndefined()
+        expect(consumable.cancellationDate).toBeUndefined()
+
+        expect(receipt.inAppPurchases[1].isInIntroOfferPeriod).toBe(true)
+    })
+
+    // Attribute types this library does not model must survive decoding with their raw bytes, so a receipt
+    // field Apple adds later stays reachable
+    it('should preserve unknown attributes', async () => {
+        const receipt = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt))
+
+        expect(receipt.unknownAttributes.get(9999)).toEqual([UNKNOWN_RECEIPT_ATTRIBUTE_VALUE])
+        expect(receipt.inAppPurchases[0].unknownAttributes.get(1799)).toEqual([UNKNOWN_IN_APP_ATTRIBUTE_VALUE])
+    })
+
+    it('should fail to verify a receipt with the wrong bundle id', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, OTHER_BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(sandboxReceipt)), VerificationStatus.INVALID_APP_IDENTIFIER)
+    })
+
+    it('should fail to verify a receipt from another environment', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(productionReceipt)), VerificationStatus.INVALID_ENVIRONMENT)
+    })
+
+    // A receipt type this library does not recognize maps to no environment at all rather than defaulting to
+    // the verifier's, so an unexpected value can never be mistaken for a match
+    it('should fail to verify a receipt with an unknown receipt type', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(unknownReceiptTypeReceipt)), VerificationStatus.INVALID_ENVIRONMENT)
+    })
+
+    it('should fail to verify a receipt with a tampered payload', async () => {
+        const tamperedReceipt = Buffer.from(sandboxReceipt)
+        // Flip a bit inside the app version of the encapsulated payload; the chain is untouched, so only the
+        // signature check can catch this
+        const appVersionIndex = tamperedReceipt.indexOf(Buffer.from(APP_VERSION))
+        expect(appVersionIndex).toBeGreaterThan(-1)
+        tamperedReceipt[appVersionIndex] ^= 0x01
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(tamperedReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    it('should fail to verify a receipt signed by a foreign root', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(foreignReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    it('should fail to verify a receipt whose leaf lacks the receipt signing OID', async () => {
+        const verifier = getReceiptVerifier(withoutReceiptSignerOidCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(withoutReceiptSignerOidReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    it('should fail to verify a receipt whose intermediate lacks the WWDR OID', async () => {
+        const verifier = getReceiptVerifier(withoutWwdrOidCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(withoutWwdrOidReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    it('should fail to verify a receipt without the root certificate embedded', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(withoutRootCertificateReceipt)), VerificationStatus.INVALID_CHAIN_LENGTH)
+    })
+
+    it('should fail to verify a receipt that is not base64', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt("!!!not-base64!!!"), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    it('should fail to verify a receipt that is not a PKCS#7 container', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(Buffer.from([1, 2, 3, 4]))), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    // Bytes appended after the container must not be ignored - a verifier that parsed a prefix would accept a
+    // receipt carrying unverified extra data
+    it('should fail to verify a receipt with trailing bytes after the container', async () => {
+        const paddedReceipt = Buffer.concat([sandboxReceipt, Buffer.alloc(4)])
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(paddedReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    // Genuine App Store receipts carry no signed attributes and sign the payload directly, unlike the
+    // containers jsrsasign's CMS generator produces, so the path every real receipt takes needs its own receipt
+    it('should verify a receipt without signed attributes', async () => {
+        const receipt = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(withoutSignedAttributesReceipt))
+        expect(receipt.bundleId).toBe(BUNDLE_ID)
+        expect(receipt.inAppPurchases.length).toBe(2)
+    })
+
+    it('should fail to verify a tampered receipt without signed attributes', async () => {
+        const tamperedReceipt = Buffer.from(withoutSignedAttributesReceipt)
+        const appVersionIndex = tamperedReceipt.indexOf(Buffer.from(APP_VERSION))
+        expect(appVersionIndex).toBeGreaterThan(-1)
+        tamperedReceipt[appVersionIndex] ^= 0x01
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(tamperedReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+
+    // Receipts outlive the certificates that signed them, so with online checks off the chain is evaluated at
+    // the receipt's creation date
+    it('should verify a receipt signed by now expired certificates', async () => {
+        const decoded = await getReceiptVerifier(expiredCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(expiredChainReceipt))
+        expect(decoded.receiptCreationDate).toBe(expiredChainCreationDate.getTime())
+    })
+
+    // Enabling online checks moves the evaluation to now, which is the point of the option: the same receipt
+    // must then fail on the expired chain
+    it('should fail to verify a receipt signed by now expired certificates with online checks enabled', async () => {
+        const verifier = getReceiptVerifier(expiredCreator, Environment.SANDBOX, BUNDLE_ID, true)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(expiredChainReceipt)), VerificationStatus.INVALID_CERTIFICATE)
+    })
+
+    // Xcode-generated receipts are not signed by the App Store, so they are decoded without any chain or
+    // signature check
+    it('should decode an Xcode receipt', async () => {
+        const decoded = await getReceiptVerifier(xcodeCreator, Environment.XCODE, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(xcodeReceipt))
+        expect(decoded.receiptType).toBe("Xcode")
+        expect(decoded.bundleId).toBe(BUNDLE_ID)
+        expect(decoded.applicationVersion).toBe(APP_VERSION)
+        expect(decoded.receiptCreationDate).toBe(RECEIPT_CREATION_DATE_MILLIS)
+        expect(decoded.inAppPurchases.length).toBe(2)
+    })
+
+    // Skipping the signature checks must not skip the app identity check
+    it('should fail to verify an Xcode receipt with the wrong bundle id', async () => {
+        const verifier = getReceiptVerifier(xcodeCreator, Environment.XCODE, OTHER_BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(xcodeReceipt)), VerificationStatus.INVALID_APP_IDENTIFIER)
+    })
+
+    // Skipping the signature checks must not skip the environment check either
+    it('should fail to verify an Xcode receipt from another environment', async () => {
+        const verifier = getReceiptVerifier(xcodeCreator, Environment.XCODE, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndDecodeAppReceipt(encode(xcodeProductionReceipt)), VerificationStatus.INVALID_ENVIRONMENT)
+    })
+
+    // The receipts Xcode generates use indefinite length encoding throughout and wrap their payload in an
+    // extra OCTET STRING, neither of which a synthetic DER receipt exercises
+    it('should decode an Xcode generated receipt', async () => {
+        const verifier = new AppReceiptVerifier([], false, Environment.XCODE, XCODE_FIXTURE_BUNDLE_ID)
+        const decoded = await verifier.verifyAndDecodeAppReceipt(readFile('tests/resources/xcode/xcode-app-receipt-with-transaction'))
+
+        expect(decoded.receiptType).toBe("Xcode")
+        expect(decoded.bundleId).toBe(XCODE_FIXTURE_BUNDLE_ID)
+        expect(decoded.applicationVersion).toBe("1")
+        expect(decoded.receiptCreationDate).toBe(new Date("2023-10-19T01:45:40Z").getTime())
+        expect(decoded.inAppPurchases.length).toBe(1)
+        expect(await verifier.verifyAndExtractTransactionId(readFile('tests/resources/xcode/xcode-app-receipt-with-transaction'))).toBe("0")
+    })
+
+    it('should decode an Xcode generated receipt without in-app purchases', async () => {
+        const verifier = new AppReceiptVerifier([], false, Environment.XCODE, XCODE_FIXTURE_BUNDLE_ID)
+        const decoded = await verifier.verifyAndDecodeAppReceipt(readFile('tests/resources/xcode/xcode-app-receipt-empty'))
+
+        expect(decoded.inAppPurchases.length).toBe(0)
+        expect(await verifier.verifyAndExtractTransactionId(readFile('tests/resources/xcode/xcode-app-receipt-empty'))).toBeNull()
+    })
+
+    it('should extract a transaction id from a verified receipt', async () => {
+        const transactionId = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(sandboxReceipt))
+        expect(transactionId).toBe(CONSUMABLE_TRANSACTION_ID)
+    })
+
+    // Same output contract as ReceiptUtility: a verified receipt with no in-app purchases yields null
+    it('should not extract a transaction id from a receipt without in-app purchases', async () => {
+        const transactionId = await getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(withoutInAppPurchasesReceipt))
+        expect(transactionId).toBeNull()
+    })
+
+    // Unlike ReceiptUtility, extraction refuses a receipt that does not verify
+    it('should not extract a transaction id from a receipt signed by a foreign root', async () => {
+        const verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false)
+        await expectVerificationFailure(verifier.verifyAndExtractTransactionId(encode(foreignReceipt)), VerificationStatus.VERIFICATION_FAILURE)
+    })
+})
+
+function getReceiptVerifier(creator: ReceiptCreator, environment: Environment, bundleId: string, enableOnlineChecks: boolean): AppReceiptVerifier {
+    return new AppReceiptVerifier([creator.getRootCertificate()], enableOnlineChecks, environment, bundleId)
+}
+
+async function expectVerificationFailure(verification: Promise<unknown>, status: VerificationStatus) {
+    try {
+        await verification
+        assert(false)
+    } catch (e) {
+        expect(e).toBeInstanceOf(VerificationException)
+        expect((e as VerificationException).status).toEqual(status)
+    }
+}
+
+function receiptPayload(receiptType: string, bundleId: string, creationDate: string): Buffer {
+    return ReceiptCreator.attributeSet()
+        .string(0, receiptType)
+        .string(2, bundleId)
+        .string(3, APP_VERSION)
+        .raw(4, OPAQUE_VALUE)
+        .raw(5, SHA1_HASH)
+        .date(12, creationDate)
+        .date(18, ORIGINAL_PURCHASE_DATE)
+        .string(19, ORIGINAL_APP_VERSION)
+        .date(21, EXPIRATION_DATE)
+        .raw(9999, UNKNOWN_RECEIPT_ATTRIBUTE_VALUE)
+        .raw(17, consumablePurchase())
+        .raw(17, subscriptionPurchase())
+        .build()
+}
+
+function consumablePurchase(): Buffer {
+    return ReceiptCreator.attributeSet()
+        .integer(1701, 1)
+        .string(1702, CONSUMABLE_PRODUCT_ID)
+        .string(1703, CONSUMABLE_TRANSACTION_ID)
+        .date(1704, CONSUMABLE_PURCHASE_DATE)
+        .string(1705, CONSUMABLE_TRANSACTION_ID)
+        .date(1706, CONSUMABLE_ORIGINAL_PURCHASE_DATE)
+        .date(1708, "")
+        .integer(1711, 42)
+        .date(1712, "")
+        .integer(1719, 0)
+        .raw(1799, UNKNOWN_IN_APP_ATTRIBUTE_VALUE)
+        .build()
+}
+
+function subscriptionPurchase(): Buffer {
+    return ReceiptCreator.attributeSet()
+        .integer(1701, 1)
+        .string(1702, SUBSCRIPTION_PRODUCT_ID)
+        .string(1703, SUBSCRIPTION_TRANSACTION_ID)
+        .date(1704, SUBSCRIPTION_PURCHASE_DATE)
+        .string(1705, SUBSCRIPTION_TRANSACTION_ID)
+        .date(1706, SUBSCRIPTION_PURCHASE_DATE)
+        .date(1708, SUBSCRIPTION_EXPIRES_DATE)
+        .integer(1711, 12345)
+        .date(1712, SUBSCRIPTION_CANCELLATION_DATE)
+        .integer(1719, 1)
+        .build()
+}
+
+function encode(receipt: Buffer): string {
+    return receipt.toString('base64')
+}
+
+function truncateToSeconds(date: Date): Date {
+    return new Date(Math.floor(date.getTime() / 1000) * 1000)
+}


### PR DESCRIPTION
Resolves #426 — and #172, which demonstrated the gap this closes: `extractTransactionIdFromAppReceipt` returns an attacker-chosen transaction ID from a hand-crafted, unsigned ASN.1 blob.

Adds `AppReceiptVerifier`, the validating counterpart to `ReceiptUtility`: it verifies the PKCS#7 app receipt's certificate chain and signature, then decodes the receipt and its in-app purchase attributes. For apps that still support iOS 14 and earlier, where StoreKit 2 isn't available, the app receipt is the only purchase artifact there is — and today the library extracts a transaction ID from it without checking that the App Store ever signed it.

This is the Node port of apple/app-store-server-library-java#268; the same shape is also open as apple/app-store-server-library-python#208 and apple/app-store-server-library-swift#133.

Design notes:

- **Maximum reuse of the existing trust code.** The embedded certificates are ordered leaf → intermediate → root and handed to `SignedDataVerifier`'s existing `verifyCertificateChain`, which already enforces the WWDR intermediate OID (1.2.840.113635.100.6.2.1) and the receipt-signing leaf OID (1.2.840.113635.100.6.11.1), against the same caller-supplied Apple root certificates. The trust evaluation is reused as-is; ordering the embedded certificates and requiring three of them is the one piece of new, trust-adjacent logic, and I'd welcome an opinion on it. It is reached through a small internal subclass because the method is `protected`; if you'd rather see the chain verification extracted into a shared helper than subclassed, happy to restructure — noted inline in the code as well.
- **Chain validity is evaluated at the receipt's creation date** (the existing `effectiveDate` parameter), so old receipts survive certificate rotations — in line with [Apple's Dec 2022 signing-certificate notice](https://developer.apple.com/news/?id=ytb7qj0x). `enableOnlineChecks` moves evaluation to the current date and enables revocation checking, matching `SignedDataVerifier`'s semantics.
- **The container is read with a small strict DER/BER reader** (~100 lines, depth-capped) rather than jsrsasign, because Xcode receipts use indefinite-length BER and segmented OCTET STRINGs, which jsrsasign's `ASN1HEX` does not parse (App Store receipts are definite-length DER; the reader takes both) — `ReceiptUtility` already patches around exactly that today. The signature is verified over the signed attributes when present (with the RFC 5652 §5.4 re-tag) or over the payload directly otherwise, which is how genuine receipts sign. This repo's committed Xcode fixtures confirm that shape (indefinite BER throughout, constructed OCTET STRING payload, no signed attributes) and the new tests decode them, though under `XCODE` that exercises the parsing rather than the signature path; the signature paths are covered by synthetic receipts.
- **No API surface beyond the new classes.** Errors map onto the existing `VerificationStatus` values; no enum additions. In the Xcode and LocalTesting environments the signature checks are skipped but the bundle id and environment are still validated, mirroring `SignedDataVerifier`.
- **Models** `AppReceipt` and `InAppPurchaseReceipt` follow the existing interface style. Attribute types the library doesn't model are preserved as raw bytes, so fields Apple adds later stay reachable without a library update.
- **`verifyAndExtractTransactionId`** has `extractTransactionIdFromAppReceipt`'s exact output contract, but only after verification; `ReceiptUtility`'s doc now cross-references it (doc-only touch there).
- **No new dependencies.**

**Adversarial review pass.** After opening this, I had the branch reviewed adversarially (independent per-language passes, each running its own probes). No verification bypass was found in any language — signature-to-payload binding, chain-to-signing-key binding, the digest allowlist, the RFC 5652 re-tag and trailing-byte rejection were each positively verified rather than assumed. What the review did find, and what a later commit here fixes, was denial of service: work reachable *before* anything about a receipt has been verified, needing no Apple key material. Attribute types were decoded through a BigInt accumulated a byte at a time and range checked only afterwards, so an 800 KB integer measured at 118 seconds with the event loop blocked; and the embedded certificates were parsed and ordered before verification with no bound on their count. Those bounds sit before the expensive step. A later pass then put a test behind each pre-verification bound and each receipt shape the verifier claims to handle — tests that fail when their bound is removed or widened by one, found by running mutations over the previous suite rather than by assuming the earlier tests covered them.

Tests generate a throwaway in-memory PKI (`ReceiptCreator`) and CMS-sign synthetic receipts — no real receipts or Apple key material. `app_receipt_verification.test.ts` holds 82 tests covering decoding, tampering, foreign roots, missing marker OIDs, chain length, trailing bytes, expired-chain-at-creation-date behavior (with and without online checks), Xcode receipts, receipts signed without signed attributes (the genuine-receipt shape), the pre-verification bounds, and the extraction contract. The full suite passes (247 tests).

The same design is shipped and cross-verified in all four library languages in [apple-purchase-receipt-verifier](https://github.com/emindeniz99/apple-purchase-receipt-verifier) (MIT), against a shared fixture suite — this PR is that implementation rewritten in this library's idiom, reusing its existing trust code instead of carrying its own.

Happy to adjust naming or shape to whatever fits the library best.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

