### PR TITLE
Make urlBase protected so makeFetchRequest overrides can use it

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,7 +202,7 @@ export class AppStoreServerAPIClient {
     private keyId: string
     private signingKey: string
     private bundleId: string
-    private urlBase: string
+    protected urlBase: string
 
     /**
      * Create an App Store Server API client


### PR DESCRIPTION
## Summary

`makeFetchRequest` (index.ts) is `protected` specifically so subclasses can override the HTTP transport, but `urlBase` was `private`, so an override had no way to read the configured base URL and had to hardcode/duplicate the production/sandbox/local-testing hosts itself. This changes `urlBase` from `private` to `protected`, matching the existing extension point.

This is a one-line visibility change with no behavior change to the public API.

Fixes the `urlBase` visibility part of #424. (The request timeout part of that issue was already addressed in #425.)

This also directly unblocks the workaround described in #352 (attaching an outbound proxy agent via a `makeFetchRequest` override), since that override can now resolve the correct host without duplicating the private constants.

## Test plan

- [x] `npx tsc -p .` builds cleanly
- [x] `npx jest` — all 20 suites / 336 tests pass
- [x] No existing tests reference `urlBase`'s visibility, so no test changes were needed