### PR TITLE
Fix AppTransactionValidator to validate receiptType

### DIFF
--- a/models/AppTransaction.ts
+++ b/models/AppTransaction.ts
@@ -138,7 +138,7 @@ export class AppTransactionValidator implements Validator<AppTransaction> {
         if ((typeof obj['preorderDate'] !== 'undefined') && !(typeof obj['preorderDate'] === "number")) {
             return false
         }
-        if ((typeof obj['environment'] !== 'undefined') && !(AppTransactionValidator.environmentValidator.validate(obj['environment']))) {
+        if ((typeof obj['receiptType'] !== 'undefined') && !(AppTransactionValidator.environmentValidator.validate(obj['receiptType']))) {
             return false
         }
         if ((typeof obj['appTransactionId'] !== 'undefined') && !(typeof obj['appTransactionId'] === "string" || obj['appTransactionId'] instanceof String)) {

--- a/tests/unit-tests/AppTransaction.test.ts
+++ b/tests/unit-tests/AppTransaction.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+import { AppTransaction, AppTransactionValidator } from "../../models/AppTransaction";
+import * as fs from 'fs';
+
+describe('AppTransaction', () => {
+    it('should deserialize AppTransaction from JSON', () => {
+        const json = fs.readFileSync('tests/resources/models/appTransaction.json', 'utf8');
+
+        const appTransaction: AppTransaction = JSON.parse(json)
+
+        expect(appTransaction.receiptType).toBe("LocalTesting")
+        expect(appTransaction.appAppleId).toBe(531412)
+        expect(appTransaction.bundleId).toBe("com.example")
+    })
+
+    it('should validate valid AppTransaction', () => {
+        const validator = new AppTransactionValidator()
+        const validAppTransaction = {
+            receiptType: "Sandbox",
+            bundleId: "com.example",
+        }
+
+        expect(validator.validate(validAppTransaction)).toBe(true)
+    })
+
+    it('should reject AppTransaction with invalid receiptType type', () => {
+        const validator = new AppTransactionValidator()
+        const invalidAppTransaction = {
+            receiptType: 123,
+            bundleId: "com.example",
+        }
+
+        expect(validator.validate(invalidAppTransaction)).toBe(false)
+    })
+
+    it('should accept AppTransaction without receiptType', () => {
+        const validator = new AppTransactionValidator()
+        const appTransaction = {
+            bundleId: "com.example",
+        }
+
+        expect(validator.validate(appTransaction)).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary

`AppTransactionValidator` was checking `obj['environment']` instead of `obj['receiptType']`. This change validates the field that the model and Apple docs actually use.

Fixes #439

## What changed

- Updated `AppTransactionValidator` to validate `receiptType` instead of `environment`
- Added unit tests for deserialization, valid payloads, invalid `receiptType` types, and missing `receiptType`

## Test plan

- [x] `npm run build`
- [x] `npm test` (21 suites, 340 tests passed)